### PR TITLE
✨ feat: Zustand useStore hook 셋팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "react-native-safe-area-context": "^4.7.1",
         "react-native-screens": "^3.23.0",
         "react-native-tab-view": "^3.5.2",
-        "react-native-web": "^0.18.12"
+        "react-native-web": "^0.18.12",
+        "zustand": "4.4.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -13881,7 +13882,7 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -13901,7 +13902,7 @@
       "version": "18.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
       "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -13923,7 +13924,7 @@
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -32923,6 +32924,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.0.tgz",
+      "integrity": "sha512-2dq6wq4dSxbiPTamGar0NlIG/av0wpyWZJGeQYtUOLegIUvhM2Bf86ekPlmgpUtS5uR7HyetSiktYrGsdsyZgQ==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-native-safe-area-context": "^4.7.1",
     "react-native-screens": "^3.23.0",
     "react-native-tab-view": "^3.5.2",
-    "react-native-web": "^0.18.12"
+    "react-native-web": "^0.18.12",
+    "zustand": "4.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,7 +5,7 @@ import {Text} from '../Text';
 export interface IButtonProps {
   disabled?: boolean;
   text: string;
-  size: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg';
   style?: any;
   onPress: () => void;
 }
@@ -31,7 +31,7 @@ const StyledButton = styled.TouchableOpacity<IStyledButton>`
 `;
 
 export const Button = (
-  {text, size, onPress, disabled = false, style}: IButtonProps,
+  {text, size = 'sm', onPress, disabled = false, style}: IButtonProps,
   props: any,
 ) => (
   <StyledButton

--- a/src/screens/auth/LandingScreen.tsx
+++ b/src/screens/auth/LandingScreen.tsx
@@ -1,18 +1,20 @@
 import {SafeAreaView} from 'react-native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {RootStackParamList} from '../../navigators';
+import useStore from '../../store/client/useStore';
 import {Text} from '../../components/Text';
 import {Button} from '../../components/Button';
+import {RootStackParamList} from '../../navigators';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Landing'>;
 
 export function LandingScreen({navigation}: Props) {
+  const {counter, increase, decrease} = useStore();
+
   return (
     <SafeAreaView>
       <Text text="TITLE TEST 1" type="head1" />
       <Text text="TITLE TEST 2" type="head2" />
       <Text text="TITLE TEST 3" type="head3" />
-
       <Button
         text="로그인"
         size="sm"
@@ -25,6 +27,11 @@ export function LandingScreen({navigation}: Props) {
         disabled={false}
         onPress={() => navigation.push('Signup')}
       />
+
+      <Text text="Store TEST " type="head1" />
+      <Text text={`${counter} ♪`} type="head2" />
+      <Button text="증가" onPress={increase} />
+      <Button text="감소" onPress={decrease} />
     </SafeAreaView>
   );
 }

--- a/src/store/client/createAuthSlice.ts
+++ b/src/store/client/createAuthSlice.ts
@@ -1,0 +1,11 @@
+import {StateCreator} from 'zustand';
+
+export interface IAuthSlice {
+  username: string;
+  changeUsername: (name: string) => void;
+}
+
+export const createAuthSlice: StateCreator<IAuthSlice> = set => ({
+  username: '',
+  changeUsername: name => set(state => ({username: name})),
+});

--- a/src/store/client/createCounterSlice.ts
+++ b/src/store/client/createCounterSlice.ts
@@ -1,0 +1,13 @@
+import {StateCreator} from 'zustand';
+
+export interface ICounterSlice {
+  counter: number;
+  increase: () => void;
+  decrease: () => void;
+}
+
+export const createCounterSlice: StateCreator<ICounterSlice> = set => ({
+  counter: 0,
+  increase: () => set(state => ({counter: state.counter + 1})),
+  decrease: () => set(state => ({counter: state.counter - 1})),
+});

--- a/src/store/client/useStore.ts
+++ b/src/store/client/useStore.ts
@@ -1,0 +1,12 @@
+import {create} from 'zustand';
+import {IAuthSlice, createAuthSlice} from './createAuthSlice';
+import {ICounterSlice, createCounterSlice} from './createCounterSlice';
+
+type TStore = IAuthSlice & ICounterSlice;
+
+const useStore = create<TStore>()((...a) => ({
+  ...createAuthSlice(...a),
+  ...createCounterSlice(...a),
+}));
+
+export default useStore;


### PR DESCRIPTION
## branch

- `main` <- `feature/zustand`

## Summary

- Zustand 환경 셋팅

## Task

- zustand 라이브러리 추가
- Slice Pattern의 Zustand Store 셋팅 ([공식 문서](https://github.com/pmndrs/zustand/blob/main/docs/guides/slices-pattern.md))
   - createOOOSlice 모듈, useStore 커스텀 훅으로 분리

## ETC

- zustand 는 client state 관리 목적으로 도입하였기 때문에 `store/client` 디렉터리에서 관리하면 좋을 것 같습니다!
- slice pattern 예제 작성을 위해 임시로 createAuthSlice, createCounterSlice 모듈을 작성하였습니다. 추후에 제거하여도 좋습니다.
- Zustand slice pattern 사용시, `useStore` import 만으로 각 slice 모듈에서 관리하는 state 과 action 을 활용할 수 있습니다. (LandingScreen 참고)
- 추가로, Zustand middleware 설정도 지원하고 있는데, 현재 단계에서는 필요성을 느끼지 못해 셋팅하지 않았습니다!
    - Zustand Middleware는 상태 변화를 추적하여 로깅, 디버깅, 비동기 작업, 상태 조작 등을 처리하는데 사용됩니다. ([공식문서](https://github.com/pmndrs/zustand#middleware))

## Issue Number

- Close #6 
