### PR TITLE
🐛 fix: Flatlist error 방지를 위한 미사용 babel plugin 제거

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,18 +2,6 @@ module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
   plugins: [
     [
-      '@babel/plugin-transform-class-properties',
-      {
-        loose: true,
-      },
-    ],
-    [
-      '@babel/plugin-transform-private-methods',
-      {
-        loose: true,
-      },
-    ],
-    [
       '@babel/plugin-transform-private-property-in-object',
       {
         loose: true,


### PR DESCRIPTION
## branch

- `main` <- `feature/fix_flatlist_error`

## Summary

- @react-navigation/material-top-tabs을 사용하고있는 RecordsScreen.tsx, MatchScreen.tsx 진입 시 아래와 같은 에러가 발생합니다.
![image](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/a2b75f8c-30ed-440a-a5f7-bdf480203dd4)


## Task

- [관련 공식 이슈 코멘트](https://github.com/facebook/react-native/issues/36828)를 참고하여, 해당 에러 방지를 위해 특정 babel plugin을 사용하지 않도록 config에서 제거합니다.
   - 현재 제거된 babel plugin들은 웹 storybook 미사용으로 인해 사용되지 않을 예정입니다.
   

## Issue Number

- Close #37 
