### PR TITLE
🐛 fix: 매칭 상세 매칭탭 프로필 navigate 이슈 해결

### DIFF
--- a/src/navigators/MatchNavigator.tsx
+++ b/src/navigators/MatchNavigator.tsx
@@ -32,7 +32,9 @@ export type MatchStackParamList = {
   MatchDetail: {
     id: number;
   };
-  MatchDetailProfile: undefined;
+  MatchDetailProfile: {
+    id: number;
+  };
   MatchDetailRecord: undefined;
   MatchDetailRecordDetail: IMatchDetailRecord;
   MatchDetailMatching: undefined;

--- a/src/screens/match/detail/MatchDetailProfileScreen.tsx
+++ b/src/screens/match/detail/MatchDetailProfileScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {type RouteProp, useRoute} from '@react-navigation/native';
 import {SafeAreaView, ScrollView, View} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
@@ -13,6 +14,7 @@ import {
   type IMatchDetail,
   type IMatchMember,
 } from '../../../features/match/types';
+import {type MatchStackParamList} from '../../../navigators';
 
 interface IMatchDetailProfileScreenProps {
   id?: number;
@@ -49,13 +51,23 @@ const MEMBER_DUMMY_DATA: IMatchMember[] = [
   },
 ];
 
+type TMatchDetailProfileScreenRouteProps = RouteProp<
+  MatchStackParamList,
+  'MatchDetailProfile'
+>;
+
 export const MatchDetailProfileScreen = ({
   id,
 }: IMatchDetailProfileScreenProps): React.JSX.Element => {
-  // TODO: 오류 화면 (서버, 404 등... 앱에서도 필요한가?) 디자인 시스템 요청드리기
-  if (id === undefined) return <View></View>;
+  const route = useRoute<TMatchDetailProfileScreenRouteProps>();
+  const paramId = route?.params?.id ?? undefined;
 
-  const {data = {fieldDto: DUMMY_DATA}} = useGetFieldDetail({id});
+  // TODO: 오류 화면 (서버, 404 등... 앱에서도 필요한가?) 디자인 시스템 요청드리기
+  if (id === undefined && paramId === undefined) return <View></View>;
+
+  const {data = {fieldDto: DUMMY_DATA}} = useGetFieldDetail({
+    id: id ?? paramId,
+  });
   const {fieldDto} = data;
 
   return (

--- a/src/screens/match/detail/matching/MatchDetailMatchingMoreScreen.tsx
+++ b/src/screens/match/detail/matching/MatchDetailMatchingMoreScreen.tsx
@@ -75,8 +75,7 @@ export const MatchDetailMatchingMoreScreen = (): React.JSX.Element => {
   };
 
   const handleTeamDetail = (matchId: number): void => {
-    // TODO: 특정 matchId의 상세 화면으로 이동시키기
-    navigation.navigate('MatchDetailProfile');
+    navigation.navigate('MatchDetailProfile', {id: matchId});
   };
 
   return (

--- a/src/screens/match/detail/matching/MatchDetailMatchingScreen.tsx
+++ b/src/screens/match/detail/matching/MatchDetailMatchingScreen.tsx
@@ -38,8 +38,7 @@ export const MatchDetailMatchingScreen = ({
   };
 
   const handleTeamDetail = (matchId: number): void => {
-    // TODO: 특정 matchId의 상세 화면으로 이동시키기
-    navigation.navigate('MatchDetailProfile');
+    navigation.navigate('MatchDetailProfile', {id: matchId});
   };
 
   return (


### PR DESCRIPTION
## branch

- `main` <- `feature/matching-navigate`

## Summary

- 매칭 상세 > 매칭탭 > ApplyListItem 클릭시, 프로필 navigate 후, 빈화면이 뜨는 이슈를 해결하였습니다.

## Task

- [x] MatchDetailProfileScreen 에서 `navigation params`를 통해 match `id`를 전달하는 방식 추가


## Issue Number

- Close #71 
