### PR TITLE
✨ feat: 홈/오늘 소모 칼로리, 최근 많이한 운동 기능 추가

### DIFF
--- a/src/features/home/components/CurrentWorkoutSection.tsx
+++ b/src/features/home/components/CurrentWorkoutSection.tsx
@@ -1,0 +1,202 @@
+import React, {useMemo, useState} from 'react';
+
+import styled from '@emotion/native';
+import {TouchableOpacity} from 'react-native';
+
+import {Gap} from '../../../components/Gap';
+import {Tag} from '../../../components/Tag';
+import {Text} from '../../../components/Text';
+import {
+  WORKOUT_ACTIVITY,
+  type HealthActivity,
+} from '../../../lib/AppleHealthKit';
+import {dayjs} from '../../../lib/dayjs';
+import {useGetRecentExercise} from '../../record/hooks/exercise';
+
+export const CurrentWorkoutSection = (): React.JSX.Element => {
+  const [selectedWorkout, setSelectedWorkout] = useState<HealthActivity | null>(
+    null,
+  );
+
+  const {data: recentExercise} = useGetRecentExercise({
+    date: dayjs().format('YYYY-MM-DD'),
+  });
+
+  const totalExerciseDurationLabel = useMemo(() => {
+    if (recentExercise === undefined) {
+      return '';
+    }
+    const hour = Math.floor(recentExercise.totalExerciseMinute / 60);
+    const minute = recentExercise.totalExerciseMinute % 60;
+    return `${hour}시간 ${minute}분`;
+  }, [recentExercise?.totalExerciseMinute]);
+
+  return (
+    <>
+      <StyledSectionLine />
+      <StyledCurrentWorkoutSection>
+        <StyledTitleContainer>
+          <Text text="최근 많이 한 운동" type="head4" fontWeight="600" />
+          <Text text="오늘" type="body2" color="gray-600" />
+        </StyledTitleContainer>
+
+        <StyledTagContainer>
+          {recentExercise?.recentSports.map((workout, index) => (
+            <TouchableOpacity
+              key={`${workout.sports}-${index}`}
+              onPress={() => {
+                setSelectedWorkout(workout.sports);
+              }}>
+              <Tag
+                hasBorder
+                type="sm"
+                fontWeight="500"
+                text={WORKOUT_ACTIVITY[workout.sports].label}
+                color={selectedWorkout === workout.sports ? 'gray-0' : 'black'}
+                borderColor={
+                  selectedWorkout === workout.sports ? 'sub-400' : 'gray-400'
+                }
+                backgroundColor={
+                  selectedWorkout === workout.sports ? 'sub-400' : 'gray-0'
+                }
+              />
+            </TouchableOpacity>
+          ))}
+        </StyledTagContainer>
+
+        <Gap size="20px" />
+
+        <StyledGraphTitle>
+          <Text
+            text="총 운동 시간"
+            type="body2"
+            color="gray-700"
+            fontWeight="600"
+          />
+          <Text
+            text={totalExerciseDurationLabel}
+            type="body2"
+            color="gray-400"
+            fontWeight="500"
+          />
+        </StyledGraphTitle>
+        <StyledGraphWrapper>
+          {recentExercise?.recentSports.map((workout, index) => (
+            <StyledGraph
+              key={`${workout.sports}-${index}`}
+              isSelected={selectedWorkout === workout.sports}
+              index={index}
+              percent={(
+                ((workout.exerciseMinute ?? 0) /
+                  (recentExercise?.totalExerciseMinute ?? 1)) *
+                100
+              ).toString()}
+              onPress={() => {
+                setSelectedWorkout(workout.sports);
+              }}
+            />
+          ))}
+        </StyledGraphWrapper>
+
+        <StyledGraphTitle>
+          <Text
+            text="총 소모 칼로리"
+            type="body2"
+            color="gray-700"
+            fontWeight="600"
+          />
+          <Text
+            text={`${recentExercise?.totalBurnedCalorie ?? 0} kcal`}
+            type="body2"
+            color="gray-400"
+            fontWeight="500"
+          />
+        </StyledGraphTitle>
+        <StyledGraphWrapper>
+          {recentExercise?.recentSports.map((workout, index) => (
+            <StyledGraph
+              key={`${workout.sports}-${index}`}
+              isSelected={selectedWorkout === workout.sports}
+              index={index}
+              percent={(
+                ((workout.burnedCalorie ?? 0) /
+                  (recentExercise?.totalBurnedCalorie ?? 1)) *
+                100
+              ).toString()}
+              onPress={() => {
+                setSelectedWorkout(workout.sports);
+              }}
+            />
+          ))}
+        </StyledGraphWrapper>
+      </StyledCurrentWorkoutSection>
+    </>
+  );
+};
+
+const StyledSectionLine = styled.View`
+  height: 10px;
+  background-color: ${({theme}) => theme.palette['gray-50']};
+`;
+
+const StyledCurrentWorkoutSection = styled.View`
+  padding: 28px 16px 14px;
+`;
+
+const StyledTitleContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const StyledGraphTitle = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-top: 12px;
+`;
+
+const StyledTagContainer = styled.View`
+  margin-top: 10px;
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+`;
+
+const StyledGraphWrapper = styled.View`
+  position: relative;
+  height: 16px;
+  background-color: ${({theme}) => theme.palette['gray-50']};
+  border-radius: ${({theme}) => theme.borderRadius.lg};
+  margin-top: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: row;
+`;
+
+const StyledGraph = styled.TouchableOpacity<{
+  isSelected: boolean;
+  percent: string;
+  index: number;
+}>`
+  background-color: ${({theme, index, isSelected}) => {
+    if (isSelected) return theme.palette['sub-400'];
+    switch (index) {
+      case 0:
+        return theme.palette['gray-700'];
+      case 1:
+        return theme.palette['gray-600'];
+      case 2:
+        return theme.palette['gray-400'];
+      case 3:
+        return theme.palette['gray-300'];
+      default:
+        return theme.palette['gray-200'];
+      // TODO(@minimalKim): 최근 운동 리스트 length 최대 확인
+    }
+  }};
+  width: ${({percent}) => `${percent}%`};
+  height: 100%;
+`;

--- a/src/features/home/components/TodayCalorieSection.tsx
+++ b/src/features/home/components/TodayCalorieSection.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+
+import {Gap} from '../../../components/Gap';
+import {Text} from '../../../components/Text';
+import {dayjs} from '../../../lib/dayjs';
+import {useGetBurnedCalorieGoal} from '../../record/hooks/exercise';
+
+export const TodayCalorieSection = (): React.JSX.Element => {
+  const today = dayjs().format('YYYY-MM-DD');
+
+  const {data: burnedCalorieGoal, refetch: refetchBurnedCalorieGoal} =
+    useGetBurnedCalorieGoal({
+      date: today,
+    });
+
+  const achievementPercent = (
+    ((burnedCalorieGoal?.burnedCalorie ?? 0) /
+      (burnedCalorieGoal?.goalCalorie ?? 1)) *
+    100
+  ).toFixed(1);
+
+  return (
+    <StyledTodayCalorieSection>
+      <Text text="오늘 소모 칼로리" type="head4" fontWeight="600" />
+      <Gap size="10px" />
+
+      <Text
+        text={
+          burnedCalorieGoal != null
+            ? `${burnedCalorieGoal.goalCalorie} kcal 중`
+            : '목표 칼로리가 없습니다'
+        }
+        type="body2"
+        fontWeight="600"
+        color="gray-600"
+      />
+
+      <StyledCalorieContainer>
+        <Text
+          text={`${burnedCalorieGoal?.burnedCalorie ?? 0} kcal`}
+          type="head2"
+          fontWeight="700"
+          color="gray-700"
+        />
+        <StyledResetButton
+          onPress={() => {
+            void refetchBurnedCalorieGoal();
+          }}>
+          <Text
+            text="새로고침"
+            type="caption"
+            fontWeight="600"
+            color="gray-600"
+          />
+        </StyledResetButton>
+      </StyledCalorieContainer>
+
+      <StyledGraphWrapper>
+        <StyledGraph percent={achievementPercent} />
+      </StyledGraphWrapper>
+
+      <StyledTextWrapper>
+        <Text
+          text={`달성률 ${achievementPercent}%`}
+          type="body3"
+          color="gray-400"
+        />
+      </StyledTextWrapper>
+    </StyledTodayCalorieSection>
+  );
+};
+
+const StyledTodayCalorieSection = styled.View`
+  padding: 28px 16px 14px;
+`;
+
+const StyledCalorieContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-top: 2px;
+`;
+
+const StyledResetButton = styled.TouchableOpacity`
+  border-radius: 12.449px;
+  background: #f0f0f5;
+  padding: 8px 11px;
+`;
+
+const StyledGraphWrapper = styled.View`
+  position: relative;
+  height: 16px;
+  background-color: ${({theme}) => theme.palette['gray-50']};
+  border-radius: ${({theme}) => theme.borderRadius.lg};
+  margin-top: 12px;
+`;
+
+const StyledGraph = styled.View<{percent: string}>`
+  position: absolute;
+  left: 0;
+  background-color: ${({theme}) => theme.palette['main-400']};
+  border-radius: ${({theme}) => theme.borderRadius.lg};
+  width: ${({percent}) => `${percent}%`};
+  height: 100%;
+`;
+
+const StyledTextWrapper = styled.View`
+  display: flex;
+  align-items: center;
+  margin-top: 8px;
+`;

--- a/src/features/home/components/index.ts
+++ b/src/features/home/components/index.ts
@@ -1,0 +1,2 @@
+export * from './CurrentWorkoutSection';
+export * from './TodayCalorieSection';

--- a/src/features/record/hooks/exercise/index.ts
+++ b/src/features/record/hooks/exercise/index.ts
@@ -4,3 +4,4 @@ export * from './useGetExerciseSummary';
 export * from './useGetRecentExercise';
 export * from './usePostAppleExercise';
 export * from './usePostExercise';
+export * from './useGetBurnedCalorieGoal';

--- a/src/features/record/hooks/exercise/keys.ts
+++ b/src/features/record/hooks/exercise/keys.ts
@@ -3,6 +3,8 @@ export const KEYS = {
   list: (date: string) => [...KEYS.all, 'list', {date}] as const,
   detail: (id: number) => [...KEYS.all, 'detail', id] as const,
   calorie: (date: string) => [...KEYS.all, 'calorie', {date}] as const,
+  burnedCalorieGoal: (date: string) =>
+    [...KEYS.all, 'burned-calorie-goal', {date}] as const,
   summary: (date: string) => [...KEYS.all, 'summary', {date}] as const,
   recent: (date: string) => [...KEYS.all, 'recent', {date}] as const,
 };

--- a/src/features/record/hooks/exercise/useGetBurnedCalorieGoal.ts
+++ b/src/features/record/hooks/exercise/useGetBurnedCalorieGoal.ts
@@ -1,0 +1,30 @@
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {axios} from '../../../../lib/axios';
+import {type IBurnedCalorieGoal} from '../../types';
+
+interface IProps {
+  date: string;
+}
+
+const fetcher = async ({date}: IProps): Promise<IBurnedCalorieGoal> =>
+  await axios
+    .get(`/exercise/calorie-state`, {
+      params: {
+        date,
+      },
+    })
+    .then(({data}) => data);
+
+export const useGetBurnedCalorieGoal = ({
+  date,
+}: IProps): UseQueryResult<IBurnedCalorieGoal, Error> =>
+  useQuery({
+    queryKey: KEYS.burnedCalorieGoal(date),
+    queryFn: async () => await fetcher({date}),
+    initialData: {
+      burnedCalorie: 0,
+      goalCalorie: 0,
+    },
+  });

--- a/src/features/record/types/exercise.ts
+++ b/src/features/record/types/exercise.ts
@@ -1,3 +1,5 @@
+import {type HealthActivity} from '../../../lib/AppleHealthKit';
+
 export interface IDailyCalories {
   burnedCalorie: number;
   goalCalorie: number;
@@ -30,8 +32,13 @@ export interface IRecentExercise {
   recentSports: Array<{
     burnedCalorie: number;
     exerciseMinute: number;
-    sports: string;
+    sports: HealthActivity;
   }>;
   totalBurnedCalorie: number;
   totalExerciseMinute: number;
+}
+
+export interface IBurnedCalorieGoal {
+  burnedCalorie: number;
+  goalCalorie: number;
 }

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 
 import {type BottomTabScreenProps} from '@react-navigation/bottom-tabs';
-import {SafeAreaView, Text} from 'react-native';
+import {SafeAreaView} from 'react-native';
 
+import {
+  CurrentWorkoutSection,
+  TodayCalorieSection,
+} from '../../features/home/components';
 import {type BottomTabStackParamList} from '../../navigators';
 
 type Props = BottomTabScreenProps<BottomTabStackParamList, 'Home'>;
@@ -10,7 +14,8 @@ type Props = BottomTabScreenProps<BottomTabStackParamList, 'Home'>;
 export function HomeScreen({navigation}: Props): React.JSX.Element {
   return (
     <SafeAreaView>
-      <Text>HomeScreen</Text>
+      <TodayCalorieSection />
+      <CurrentWorkoutSection />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## branch

- `develop` <- `feat/OOO`

## Summary

- 홈 스크린 내 '오늘 소모 칼로리', '최근 많이한 운동' 기능을 추가합니다.


<img src="https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/55276652-99a5-4e93-88c9-f41723d7e5b0" alt="drawing" width="400"/>


## Task

- 오늘 소모 칼로리
  - [x] 컴포넌트 스타일 구현
  - [x] backend API 연동
  - [x] 새로고침 클릭 시 refetch 기능 구현

- 최근 많이 한 운동
  - [x] 컴포넌트 스타일 구현
  - [x] backend API 연동
  - [x] 태그  및 그래프 영역 클릭 시, 선택 운동 변경 기능 구현
  
## ETC

- `useGetRecentExercise` 응답값 `recentSports` 최대 length 확인 필요

## Issue Number

- Close #59 
