### PR TITLE
🔨 refactor: theme type 선언 수정

### DIFF
--- a/src/assets/styles/emotion.d.ts
+++ b/src/assets/styles/emotion.d.ts
@@ -1,46 +1,17 @@
 import '@emotion/react';
+import {type theme} from './theme';
 
-export type Tpalette =
-  | 'main-400'
-  | 'main-300'
-  | 'main-200'
-  | 'main-100'
-  | 'error-light'
-  | 'error-dark'
-  | 'sub-400'
-  | 'gray-0'
-  | 'gray-50'
-  | 'gray-100'
-  | 'gray-200'
-  | 'gray-300'
-  | 'gray-400'
-  | 'gray-500'
-  | 'gray-600'
-  | 'gray-700'
-  | 'gray-800'
-  | 'gray-900'
-  | 'gray-950'
-  | 'black';
-
-export type Ttypography =
-  | 'head1'
-  | 'head2'
-  | 'head3'
-  | 'head4'
-  | 'body1'
-  | 'body2'
-  | 'body3'
-  | 'caption';
-
-export type TBorderRadius = 'sm' | 'md' | 'lg';
+export type TPalette = keyof typeof theme.palette;
+export type TTypography = keyof typeof theme.typography;
+export type TBorderRadius = keyof typeof theme.borderRadius;
 
 declare module '@emotion/react' {
   export interface Theme {
     palette: {
-      [key in Tpalette]: string;
+      [key in TPalette]: string;
     };
     typography: {
-      [key in Ttypography]: {
+      [key in TTypography]: {
         fontFamily: string;
         fontSize: string | number;
       };

--- a/src/assets/styles/emotion.d.ts
+++ b/src/assets/styles/emotion.d.ts
@@ -7,17 +7,8 @@ export type TBorderRadius = keyof typeof theme.borderRadius;
 
 declare module '@emotion/react' {
   export interface Theme {
-    palette: {
-      [key in TPalette]: string;
-    };
-    typography: {
-      [key in TTypography]: {
-        fontFamily: string;
-        fontSize: string | number;
-      };
-    };
-    borderRadius: {
-      [key in TBorderRadius]: string;
-    };
+    palette: typeof theme.palette;
+    typography: typeof theme.typography;
+    borderRadius: typeof theme.borderRadius;
   }
 }

--- a/src/assets/styles/theme.ts
+++ b/src/assets/styles/theme.ts
@@ -19,7 +19,7 @@ const palette = {
   'gray-900': '#2B2D36',
   'gray-950': '#252730',
   black: '#000000',
-};
+} as const;
 
 const typography = {
   head1: {
@@ -54,13 +54,13 @@ const typography = {
     fontFamily: 'Pretendard-Regular',
     fontSize: '12px',
   },
-};
+} as const;
 
 const borderRadius = {
   sm: '8px',
   md: '12px',
   lg: '22px',
-};
+} as const;
 
 export const theme = {
   palette,

--- a/src/components/Alarm/AlarmItem.tsx
+++ b/src/components/Alarm/AlarmItem.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from '@emotion/native';
 import {View} from 'react-native';
 
-import {type Tpalette} from '../../assets/styles/emotion';
+import {type TPalette} from '../../assets/styles/emotion';
 import {dayjs} from '../../lib/dayjs';
 import {checkValidDateTimeFormat} from '../../utils/regex';
 import {Gap} from '../Gap';
@@ -16,13 +16,13 @@ export interface IAlarmItemProps {
 }
 
 interface IStyledAlarmIcon {
-  color: Tpalette;
+  color: TPalette;
 }
 
 interface IAlarmTypeData {
-  matching: {text: string; color: Tpalette};
-  member: {text: string; color: Tpalette};
-  team: {text: string; color: Tpalette};
+  matching: {text: string; color: TPalette};
+  member: {text: string; color: TPalette};
+  team: {text: string; color: TPalette};
 }
 
 export const AlarmItem = ({

--- a/src/components/Button/NavigateButton.tsx
+++ b/src/components/Button/NavigateButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from '@emotion/native';
 
-import {type Tpalette} from '../../assets/styles/emotion';
+import {type TPalette} from '../../assets/styles/emotion';
 import {arrowRightXmlData} from '../../assets/svg';
 import {Icon} from '../Icon';
 import {Text} from '../Text';
@@ -10,15 +10,15 @@ import {Text} from '../Text';
 export interface INavigateButtonProps {
   text: string;
   width?: string;
-  color?: Tpalette;
-  backgroundColor?: Tpalette;
+  color?: TPalette;
+  backgroundColor?: TPalette;
   onPress: () => void;
 }
 
 interface IStyledNavigateButton {
   width: string;
-  color: Tpalette;
-  backgroundColor: Tpalette;
+  color: TPalette;
+  backgroundColor: TPalette;
 }
 
 export const NavigateButton = ({

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 
 import styled from '@emotion/native';
 
-import {type Tpalette, type Ttypography} from '../../assets/styles/emotion';
+import {type TPalette, type TTypography} from '../../assets/styles/emotion';
 import {Text} from '../Text';
 
 interface ICommonTag {
   type: 'xs' | 'sm' | 'md' | 'lg';
   fontWeight?: string;
   hasBorder: boolean;
-  color?: Tpalette;
-  backgroundColor: Tpalette;
-  borderColor: Tpalette;
+  color?: TPalette;
+  backgroundColor: TPalette;
+  borderColor: TPalette;
 }
 
 export interface ITagProps extends ICommonTag {
@@ -23,7 +23,7 @@ export interface ITagsProps extends ICommonTag {
 }
 
 interface ITagTypeStyle {
-  textType: Ttypography;
+  textType: TTypography;
   padding: string;
 }
 

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import styled from '@emotion/native';
 import {type StyleProp, type TextProps, type TextStyle} from 'react-native';
 
-import {type Tpalette, type Ttypography} from '../../assets/styles/emotion';
+import {type TPalette, type TTypography} from '../../assets/styles/emotion';
 
 export interface ITextProps extends TextProps {
   text: string;
-  type?: Ttypography;
-  color?: Tpalette;
+  type?: TTypography;
+  color?: TPalette;
   fontWeight?: string;
   lineHeight?: string;
   textAlign?: string;
@@ -16,8 +16,8 @@ export interface ITextProps extends TextProps {
 }
 
 interface IStyledText {
-  type: Ttypography;
-  color: Tpalette;
+  type: TTypography;
+  color: TPalette;
   fontWeight?: string;
   lineHeight?: string;
   textAlign?: string;


### PR DESCRIPTION
## branch

- `main` <- `feature/type-refactor`

## Summary

- 기존에 작성되어 있던 theme type을 `상수 타입 활용` 방식으로 변경하였습니다.
- 타입 변수명을 수정하였습니다.

## Task

- [x] emotion.d.ts 파일 수정 
- [x] 수정된 타입 변수명 적용 

## ETC


## Issue Number

- Close #80 