### PR TITLE
✨ feat: 매칭 생성 API 연동 및 상세 페이지 연동

### DIFF
--- a/src/features/match/components/CreateMatchInformation/CreateMatchInformationItem.tsx
+++ b/src/features/match/components/CreateMatchInformation/CreateMatchInformationItem.tsx
@@ -21,12 +21,20 @@ export const CreateMatchInformationItem = ({
   pick,
   handlePick,
 }: ICreateMatchInformationItemProps): React.JSX.Element => {
+  const fieldData = {
+    fieldType: FieldTypes,
+    period: Periods,
+    goal: Goals,
+    skillLevel: SkillLevels,
+    strength: Strengths,
+  };
+
   const radioData = {
-    fieldType: Object.values(FieldTypes),
-    period: Object.values(Periods),
-    goal: Object.values(Goals),
-    skillLevel: Object.values(SkillLevels),
-    strength: Object.values(Strengths),
+    fieldType: Object.keys(FieldTypes) as Array<keyof typeof FieldTypes>,
+    period: Object.keys(Periods) as Array<keyof typeof Periods>,
+    goal: Object.keys(Goals) as Array<keyof typeof Goals>,
+    skillLevel: Object.keys(SkillLevels) as Array<keyof typeof SkillLevels>,
+    strength: Object.keys(Strengths) as Array<keyof typeof Strengths>,
   };
 
   return (
@@ -34,6 +42,7 @@ export const CreateMatchInformationItem = ({
       <Text type="body1" text={label} />
       <MatchCreateRadio
         field={field}
+        fieldData={fieldData[field]}
         radioData={radioData[field]}
         pick={pick}
         handlePick={handlePick}

--- a/src/features/match/components/CreateMatchProfile/CreateMatchProfileSection.tsx
+++ b/src/features/match/components/CreateMatchProfile/CreateMatchProfileSection.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, {useState} from 'react';
 
 import styled from '@emotion/native';
 import {Image} from 'react-native';
-import {launchImageLibrary, type Asset} from 'react-native-image-picker';
+import {launchImageLibrary} from 'react-native-image-picker';
 
 import {theme} from '../../../../assets/styles/theme';
 import {plusXmlData} from '../../../../assets/svg';
@@ -51,18 +51,25 @@ export const CreateMatchProfileSection = ({
   createMatchProfilePayload,
   onChange,
 }: ICreateMatchProfileSectionProps): React.JSX.Element => {
-  const {profileImg, name, description, rule} = createMatchProfilePayload;
+  const [profileImgPreview, setProfileImgPreview] = useState('');
+
+  const {name, description, rule} = createMatchProfilePayload;
 
   const handleImagePicker = (): void => {
     void launchImageLibrary(
       {
         mediaType: 'photo',
       },
-      response => {
+      async response => {
         if (response.assets != null) {
-          const selectedAsset: Asset = response.assets[0];
-          onChange('profileImg', selectedAsset.uri ?? '');
-          // TODO: 서버 이미지 업로드
+          const {uri, type, fileName} = response.assets[0];
+
+          // TODO: 에러처리
+          if (uri === undefined || type === undefined || fileName === undefined)
+            return;
+
+          onChange('profileImg', uri);
+          setProfileImgPreview(uri);
         } else {
           // TODO: 에러 처리
         }
@@ -73,9 +80,9 @@ export const CreateMatchProfileSection = ({
   return (
     <>
       <StyledProfileWrapper activeOpacity={0.8} onPress={handleImagePicker}>
-        {profileImg !== '' ? (
+        {profileImgPreview !== '' ? (
           <Image
-            source={{uri: profileImg}}
+            source={{uri: profileImgPreview}}
             style={{width: '100%', height: '100%', borderRadius: 142}}
           />
         ) : (

--- a/src/features/match/components/CreateMatchProfile/MatchInformationSection.tsx
+++ b/src/features/match/components/CreateMatchProfile/MatchInformationSection.tsx
@@ -7,6 +7,7 @@ import {Gap} from '../../../../components/Gap';
 import {Line} from '../../../../components/Line';
 import {Text} from '../../../../components/Text';
 import useStore from '../../../../store/client/useStore';
+import {FieldTypes, Goals, Periods, SkillLevels, Strengths} from '../../const';
 
 interface IMatchInformationSectionProps {
   handleUpdateMatchInformation: () => void;
@@ -52,12 +53,12 @@ export const MatchInformationSection = ({
 
       <Gap size="20px" />
 
-      <MatchInformationItem label="매칭 유형" value={fieldType} />
+      <MatchInformationItem label="매칭 유형" value={FieldTypes[fieldType]} />
       <MatchInformationItem label="팀 인원" value={maxSize.toString()} />
-      <MatchInformationItem label="진행기간" value={period} />
-      <MatchInformationItem label="카테고리" value={goal} />
-      <MatchInformationItem label="운동 레벨" value={skillLevel} />
-      <MatchInformationItem label="운동 강도" value={strength} />
+      <MatchInformationItem label="진행기간" value={Periods[period]} />
+      <MatchInformationItem label="카테고리" value={Goals[goal]} />
+      <MatchInformationItem label="운동 레벨" value={SkillLevels[skillLevel]} />
+      <MatchInformationItem label="운동 강도" value={Strengths[strength]} />
     </StyledMatchInformationSectionWrapper>
   );
 };

--- a/src/features/match/components/MatchDetailProfile/MatchDetailMembers.tsx
+++ b/src/features/match/components/MatchDetailProfile/MatchDetailMembers.tsx
@@ -5,12 +5,12 @@ import styled from '@emotion/native';
 import {arrowRightXmlData} from '../../../../assets/svg';
 import {Icon} from '../../../../components/Icon';
 import {Text} from '../../../../components/Text';
-import {type IMatchMember} from '../../types/member';
+import {type IUserFieldListInfo} from '../../types';
 
 interface IMatchDetailMembersProps {
   currentSize: number;
   maxSize: number;
-  members: IMatchMember[];
+  members: IUserFieldListInfo | undefined;
 }
 
 export const MatchDetailMembers = ({
@@ -29,7 +29,7 @@ export const MatchDetailMembers = ({
         <Icon svgXml={arrowRightXmlData} width={40} height={40} />
       </StyledHeaderWrapper>
       <StyledMemberWrapper>
-        {members.map(member => (
+        {members?.map(member => (
           <StyledMember key={`member-${member.id}`} />
         ))}
       </StyledMemberWrapper>

--- a/src/features/match/components/MatchDetailProfile/MatchDetailProfileSection.tsx
+++ b/src/features/match/components/MatchDetailProfile/MatchDetailProfileSection.tsx
@@ -8,11 +8,10 @@ import {Line} from '../../../../components/Line';
 import {Tag, Tags} from '../../../../components/Tag';
 import {Text} from '../../../../components/Text';
 import {FieldTypes, Goals, Periods, SkillLevels, Strengths} from '../../const';
-import {type IMatchDetail} from '../../types/detail';
+import {type IFieldDetailInfo} from '../../types/detail';
 
 interface IMatchDetailProfileSectionProps {
-  detailInfo: IMatchDetail;
-  isMember: boolean;
+  detailInfo: IFieldDetailInfo;
 }
 
 interface IStausTagProps {
@@ -21,13 +20,19 @@ interface IStausTagProps {
 
 const StatusTag = ({text}: IStausTagProps): React.JSX.Element => {
   return (
-    <Tag type="sm" color="gray-0" backgroundColor="main-300" text={text} />
+    <Tag
+      type="sm"
+      color="gray-0"
+      backgroundColor="main-300"
+      hasBorder={false}
+      borderColor="main-300"
+      text={text}
+    />
   );
 };
 
 export const MatchDetailProfileSection = ({
   detailInfo,
-  isMember,
 }: IMatchDetailProfileSectionProps): React.JSX.Element => {
   const {
     // profileImg,
@@ -39,9 +44,16 @@ export const MatchDetailProfileSection = ({
     period,
     skillLevel,
     strength,
-  } = detailInfo;
+    fieldRole,
+    currentSize,
+    maxSize,
+  } = detailInfo.fieldDto;
 
   const filedTypeLabel = FieldTypes[fieldType];
+  const fieldStatus =
+    currentSize === maxSize
+      ? `팀원 모집 완료 ${currentSize}/${maxSize}`
+      : `팀원 모집 중 ${currentSize}/${maxSize}`;
   const periodLabel = `${Periods[period]}동안`;
   const goalLabel = Goals[goal];
   const skillLevelLabel = `운동 레벨 ${SkillLevels[skillLevel]}`;
@@ -53,13 +65,13 @@ export const MatchDetailProfileSection = ({
         <StyledProfileInformation>
           <StyledProfile />
           <View>
-            <StatusTag text="팀 매칭" />
+            <StatusTag text={filedTypeLabel} />
             <Gap size="6px" />
-            <StatusTag text="팀원 모집 중" />
+            <StatusTag text={fieldStatus} />
           </View>
         </StyledProfileInformation>
 
-        {isMember && (
+        {fieldRole === 'LEADER' && (
           <TouchableOpacity activeOpacity={0.8}>
             <Text type="body2" color="gray-600" fontWeight="400" text="설정" />
           </TouchableOpacity>
@@ -84,16 +96,20 @@ export const MatchDetailProfileSection = ({
 
       <Tags
         type="sm"
+        hasBorder={false}
         color="gray-700"
         backgroundColor="gray-50"
+        borderColor="gray-50"
         fontWeight="400"
         texts={[filedTypeLabel, periodLabel, goalLabel]}
       />
       <Gap size="8px" />
       <Tags
         type="sm"
+        hasBorder={false}
         color="gray-700"
         backgroundColor="gray-50"
+        borderColor="gray-50"
         fontWeight="400"
         texts={[skillLevelLabel, strengthLabel]}
       />

--- a/src/features/match/components/MatchRadio/MatchCreateRadio.tsx
+++ b/src/features/match/components/MatchRadio/MatchCreateRadio.tsx
@@ -7,6 +7,7 @@ import {type ICreateField} from '../../types';
 
 interface IMatchCreateRadioProps {
   field: keyof ICreateField;
+  fieldData: Record<string, string>;
   radioData: string[];
   pick: string;
   handlePick: (value: string | number) => void;
@@ -20,6 +21,7 @@ export const MatchCreateRadio = ({
   field,
   radioData,
   pick,
+  fieldData,
   handlePick,
 }: IMatchCreateRadioProps): React.JSX.Element => {
   return (
@@ -36,7 +38,7 @@ export const MatchCreateRadio = ({
             type="body2"
             fontWeight={pick === value ? '700' : '400'}
             color={pick === value ? 'gray-0' : 'gray-600'}
-            text={value}
+            text={fieldData[value] ?? '-'}
           />
         </StyledRadioItem>
       ))}

--- a/src/features/match/hooks/field/usePostField.ts
+++ b/src/features/match/hooks/field/usePostField.ts
@@ -3,23 +3,31 @@ import {type UseMutationResult, useMutation} from '@tanstack/react-query';
 import {KEYS} from './keys';
 import {axios} from '../../../../lib/axios';
 import {queryClient} from '../../../../lib/react-query';
-import {type ICreateField} from '../../types';
 
 interface IProps {
-  body: ICreateField;
+  formData: FormData;
 }
 
-const fetcher = async ({body}: IProps): Promise<string> =>
+interface IUsePostFieldProps {
+  onSuccessCallback: (id: string) => void;
+}
+
+const fetcher = async ({formData}: IProps): Promise<string> =>
   await axios
-    .post(`/field`, {
-      body,
+    .post('/field', formData, {
+      headers: {
+        'content-type': 'multipart/form-data',
+      },
     })
     .then(({data}) => data);
 
-export const usePostField = (): UseMutationResult<string, Error, IProps> => {
+export const usePostField = ({
+  onSuccessCallback,
+}: IUsePostFieldProps): UseMutationResult<string, Error, IProps> => {
   return useMutation({
     mutationFn: fetcher,
-    onSuccess: () => {
+    onSuccess: response => {
+      onSuccessCallback(response);
       void queryClient.invalidateQueries(KEYS.all);
     },
   });

--- a/src/features/match/types/detail.ts
+++ b/src/features/match/types/detail.ts
@@ -1,27 +1,22 @@
 import {
   type TPeriod,
   type TFieldType,
-  type TGoal,
   type TSkillLevel,
   type TStrength,
+  type IField,
 } from '.';
 import {type TWorkoutActivitiesType} from '../../../lib/AppleHealthKit';
 
-// 프로필 탭
-export interface IMatchDetail {
-  id: number;
-  profileImg: string;
-  name: string;
-  description: string;
-  rule: string;
-  fieldType: TFieldType;
-  goal: TGoal;
-  period: TPeriod;
-  skillLevel: TSkillLevel;
-  strength: TStrength;
-  currentSize: number;
-  maxSize: number;
-  endDate: string;
+export interface IFieldDetailInfo {
+  assignedFieldDto: IField;
+  fieldDto: IField & {
+    description: string;
+    endDate: string;
+    fieldRole: 'LEADER' | 'MEMBER' | 'GUEST';
+    fieldStatus: 'COMPLETED' | 'IN_PROGRESS' | 'RECRUITING';
+    rule: string;
+    strength: TStrength;
+  };
 }
 
 export interface IMatchDetailRecord {

--- a/src/features/match/types/userField.ts
+++ b/src/features/match/types/userField.ts
@@ -1,8 +1,10 @@
+import {type TSkillLevel} from '.';
+
 export interface IUserFieldListInfo
   extends Array<{
     id: number;
     isLeader: boolean;
     name: string;
     profileImg: string;
-    skillLevel: string;
+    skillLevel: TSkillLevel;
   }> {}

--- a/src/screens/match/create/CreateMatchInformationScreen.tsx
+++ b/src/screens/match/create/CreateMatchInformationScreen.tsx
@@ -44,17 +44,17 @@ export const CreateMatchInformationScreen = ({
     createMatchPayload;
 
   const isAbleMemberCountPayload =
-    fieldType === '1vs1' ? maxSize === 1 : maxSize >= 2 && maxSize <= 10;
+    fieldType === 'DUEL' ? maxSize === 1 : maxSize >= 2 && maxSize <= 10;
 
   const isAblePayload =
-    Object.values(FieldTypes).some(value => value === fieldType) &&
-    Object.values(Periods).some(value => value === period) &&
-    Object.values(Goals).some(value => value === goal) &&
-    Object.values(SkillLevels).some(value => value === skillLevel) &&
-    Object.values(Strengths).some(value => value === strength) &&
+    Object.keys(FieldTypes).some(value => value === fieldType) &&
+    Object.keys(Periods).some(value => value === period) &&
+    Object.keys(Goals).some(value => value === goal) &&
+    Object.keys(SkillLevels).some(value => value === skillLevel) &&
+    Object.keys(Strengths).some(value => value === strength) &&
     isAbleMemberCountPayload;
 
-  const isPersonalMatching = fieldType === '1vs1';
+  const isPersonalMatching = fieldType === 'DUEL';
   const isMinimumOfMemberCount = maxSize <= 2;
   const isMaximumOfMemberCount = maxSize >= 10;
 
@@ -69,7 +69,7 @@ export const CreateMatchInformationScreen = ({
 
   const handleMatchingPayload = (value: string | number): void => {
     handleCreateMatchPayload('fieldType', value);
-    if (value === '1vs1') {
+    if (value === 'DUEL') {
       handleCreateMatchPayload('maxSize', 1);
     } else {
       handleCreateMatchPayload('maxSize', 2);
@@ -99,7 +99,7 @@ export const CreateMatchInformationScreen = ({
           }}
         />
 
-        {Object.values(FieldTypes).some(value => value === fieldType) && (
+        {Object.keys(FieldTypes).some(value => value === fieldType) && (
           <StyledInputView>
             <Text type="body1" text="팀 인원수" />
             <Gap size="30px" />

--- a/src/screens/match/detail/MatchDetailScreen.tsx
+++ b/src/screens/match/detail/MatchDetailScreen.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from '@emotion/native';
 import {type RouteProp, useRoute} from '@react-navigation/native';
 import {type NativeStackScreenProps} from '@react-navigation/native-stack';
-import {SafeAreaView} from 'react-native';
+import {SafeAreaView, View} from 'react-native';
 
 import {MatchDetailMemberScreen} from './MatchDetailMemberScreen';
 import {MatchDetailProfileScreen} from './MatchDetailProfileScreen';
@@ -15,6 +15,7 @@ import {
   type ITopTabScreen,
   TopTabNavigator,
 } from '../../../components/TopTabNavigator';
+import {useGetFieldDetail} from '../../../features/match/hooks/field';
 import {type MatchStackParamList} from '../../../navigators/MatchNavigator';
 
 type TMatchDetailScreenProps = NativeStackScreenProps<
@@ -33,28 +34,63 @@ export const MatchDetailScreen = ({
   const route = useRoute<TMatchDetailScreenRouteProps>();
   const {id} = route.params;
 
-  const screens: ITopTabScreen[] = [
-    {
-      name: 'TeamProfile',
-      label: '프로필',
-      component: () => <MatchDetailProfileScreen id={id} />,
-    },
-    {
-      name: 'TeamRecord',
-      label: '기록',
-      component: () => <MatchDetailRecordScreen id={id} />,
-    },
-    {
-      name: 'TeamMatching',
-      label: '매칭',
-      component: MatchDetailMatchingScreen,
-    },
-    {
-      name: 'TeamMember',
-      label: '팀원',
-      component: MatchDetailMemberScreen,
-    },
-  ];
+  // TODO: ERR 처리
+  if (id === undefined) return <View></View>;
+
+  // TODO: 다른 접근에 대해서도 처리 (생성 후 프로필 상세 등)
+  const {data: fieldDetailData} = useGetFieldDetail({
+    id,
+  });
+
+  const getScreenByRule = (): ITopTabScreen[] => {
+    const userRole = fieldDetailData?.fieldDto?.fieldRole;
+
+    switch (userRole) {
+      case 'MEMBER':
+      case 'LEADER':
+        return [
+          {
+            name: 'TeamProfile',
+            label: '프로필',
+            component: () => (
+              <MatchDetailProfileScreen fieldDetailData={fieldDetailData} />
+            ),
+          },
+          {
+            name: 'TeamRecord',
+            label: '기록',
+            component: () => <MatchDetailRecordScreen id={id} />,
+          },
+          {
+            name: 'TeamMatching',
+            label: '매칭',
+            component: MatchDetailMatchingScreen,
+          },
+          {
+            name: 'TeamMember',
+            label: '팀원',
+            component: MatchDetailMemberScreen,
+          },
+        ];
+      default:
+        return [
+          {
+            name: 'TeamProfile',
+            label: '프로필',
+            component: () => (
+              <MatchDetailProfileScreen fieldDetailData={fieldDetailData} />
+            ),
+          },
+          {
+            name: 'TeamMember',
+            label: '팀원',
+            component: MatchDetailMemberScreen,
+          },
+        ];
+    }
+  };
+
+  const screens = getScreenByRule();
 
   return (
     <>


### PR DESCRIPTION
## branch

- `main` <- `feature/create-field-api`

## Summary

| 정보 입력 | 프로필 입력 | 매칭 생성 후 상세 페이지 이동 |
|--------|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-08 at 17 54 19](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/0633aebb-0bf1-4204-97c7-5a9fea9023f1) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-08 at 17 54 54](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/420f0acc-d8d4-4bcf-b585-8294df4cdc2d) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-08 at 17 55 02](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/a35a2c80-e442-4fa0-b174-cc05813085c0) |




- 매칭 생성 API (POST /field)를 연동하였습니다. (formData 방식)
- 매칭 생성 성공 후, callBack 로직을 작성하였습니다.

## Task

- [x] 매칭 생성 API 연동
- [x] 매칭 생성 성공 후, 상세 화면 navigation 연동

## ETC


## Issue Number

- Close #85 
