### PR TITLE
✨ feat: axios 배열 파라미터 복수키 포맷 변경 

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -10,6 +10,18 @@ export const axios = Axios.create({
   },
 });
 
+axios.defaults.paramsSerializer = function (paramObj) {
+  const params = new URLSearchParams();
+
+  for (const key in paramObj) {
+    if (paramObj[key] !== null && paramObj[key] !== undefined) {
+      params.append(key, paramObj[key]);
+    }
+  }
+
+  return params.toString();
+};
+
 axios.interceptors.request.use(async config => {
   // TODO: jwt 관련 설정 추가
   // const token = await asyncStorage.get<string>(ASYNC_STORAGE_KEYS.AUTH_JWT);

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -14,8 +14,16 @@ axios.defaults.paramsSerializer = function (paramObj) {
   const params = new URLSearchParams();
 
   for (const key in paramObj) {
-    if (paramObj[key] !== null && paramObj[key] !== undefined) {
-      params.append(key, paramObj[key]);
+    const value = paramObj[key];
+
+    if (Array.isArray(value)) {
+      value.forEach((item: any) => {
+        if (item !== null && item !== undefined) {
+          params.append(key, item);
+        }
+      });
+    } else if (value !== null && value !== undefined) {
+      params.append(key, value);
     }
   }
 


### PR DESCRIPTION
## branch

- `main` <- `feature/axios-array-param`

## Summary

- axios 배열 파라미터 복수키 포맷을 변경합니다. (`url?key[]=value1&key[]=value2` -> `url?key=value1&key=value2`)
  - 현재 백엔드에서 `ModelAttribute` 어노테이션을 활용하여 파라미터를 받고 있는데, 배열 포맷의 파라미터를 처리하려면 하드코딩으로 이어짐. 따라서 프론트에서 복수키 포맷 변경

## Task

- [x] axios default paramsSerializer 셋팅
  - null, undefined 값은 제외시킴


## Issue Number

- Close #94 
