### PR TITLE
🔨 refactor: 매칭 리스트 - API 변동에 따른 응답값 수정

### DIFF
--- a/src/features/match/components/MatchFilter/MatchFieldTypeFilterRadio.tsx
+++ b/src/features/match/components/MatchFilter/MatchFieldTypeFilterRadio.tsx
@@ -36,6 +36,7 @@ export const MatchFieldTypeFilterRadio = ({
           activeOpacity={0.8}
           onPress={() => {
             navigation.navigate('MatchList', {
+              fieldId: null,
               page,
               size,
               fieldType: value,

--- a/src/features/match/hooks/field/index.ts
+++ b/src/features/match/hooks/field/index.ts
@@ -2,3 +2,4 @@ export * from './useGetAutoField';
 export * from './useGetFieldDetail';
 export * from './useGetInfiniteFieldList';
 export * from './usePostField';
+export * from './useGetFieldCount';

--- a/src/features/match/hooks/field/keys.ts
+++ b/src/features/match/hooks/field/keys.ts
@@ -1,10 +1,14 @@
-import {type TFieldType, type IFieldListPaginationParams} from '../../types';
+import {
+  type TFieldType,
+  type IFieldListPaginationParams,
+  type IFieldListParams,
+} from '../../types';
 
 export const KEYS = {
   all: ['field'] as const,
   list: ({
-    pageSize,
-    pageNumber,
+    page,
+    size,
     fieldType,
     goal,
     memberCount,
@@ -16,8 +20,8 @@ export const KEYS = {
       ...KEYS.all,
       'list',
       {
-        pageSize,
-        pageNumber,
+        page,
+        size,
         fieldType,
         goal,
         memberCount,
@@ -25,6 +29,20 @@ export const KEYS = {
         skillLevel,
         strength,
       },
+    ] as const,
+  count: ({
+    fieldType,
+    goal,
+    memberCount,
+    period,
+    skillLevel,
+    strength,
+    keyword,
+  }: IFieldListParams) =>
+    [
+      ...KEYS.all,
+      'count',
+      {fieldType, goal, memberCount, period, skillLevel, strength, keyword},
     ] as const,
   detail: (id: number) => [...KEYS.all, 'detail', id] as const,
   detailTerminate: (id: number) => [...KEYS.detail(id), 'terminate'] as const,

--- a/src/features/match/hooks/field/useGetFieldCount.ts
+++ b/src/features/match/hooks/field/useGetFieldCount.ts
@@ -1,0 +1,60 @@
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {axios} from '../../../../lib/axios';
+import {type IFieldListParams} from '../../types';
+
+const fetcher = async ({
+  fieldType,
+  goal,
+  memberCount,
+  period,
+  skillLevel,
+  strength,
+  keyword,
+}: IFieldListParams): Promise<number> =>
+  await axios
+    .get('/field/count', {
+      params: {
+        fieldType,
+        goal,
+        memberCount,
+        period,
+        skillLevel,
+        strength,
+        keyword,
+      },
+    })
+    .then(({data}) => data);
+
+export const useGetFieldCount = ({
+  fieldType,
+  goal,
+  memberCount,
+  period,
+  skillLevel,
+  strength,
+  keyword,
+}: IFieldListParams): UseQueryResult<number, Error> =>
+  useQuery({
+    queryKey: KEYS.count({
+      fieldType,
+      goal,
+      memberCount,
+      period,
+      skillLevel,
+      strength,
+      keyword,
+    }),
+    queryFn: async () =>
+      await fetcher({
+        fieldType,
+        goal,
+        memberCount,
+        period,
+        skillLevel,
+        strength,
+        keyword,
+      }),
+    initialData: 0,
+  });

--- a/src/features/match/types/field.ts
+++ b/src/features/match/types/field.ts
@@ -7,6 +7,7 @@ import {
 } from '.';
 
 export interface IFieldListPaginationParams extends IFieldListParams {
+  fieldId?: number | null;
   page: number;
   size: number;
 }

--- a/src/navigators/MatchNavigator.tsx
+++ b/src/navigators/MatchNavigator.tsx
@@ -84,6 +84,7 @@ export function MatchNavigator(): React.JSX.Element {
           headerShown: false,
         }}
         initialParams={{
+          fieldId: null,
           page: 0,
           size: 10,
           fieldType: 'DUEL',


### PR DESCRIPTION
## branch

- `main` <- `feature/match-list-refactor`

## Summary

- 매칭 리스트 무한스크롤 관련 API 변동에 따른 응답값을 수정하였습니다.

## Task

- [x] useGetInfiniteFieldList 변경 사항 반영 (`GET /field`)
  - [x] fieldId 파라미터 추가

- [x] useGetFieldCount 연동 (`GET /field/count`)

- [x] FlatList 가 제공하는 `ListEmptyComponent` 인자 활용

## ETC

- API 응답값 변경에 따라 `useInfiniteQuery` 에서 다음 데이터를 불러오는 로직이 간단해졌습니다. 마지막으로 불러와진 매칭 데이터의 `id` 값을 넘겨주는 방식으로 변경되었습니다. 존재하지 않는다면 `undefined` 를 리턴하며 마칩니다.

```js
getNextPageParam: lastPage => {
  const {fieldsInfos} = lastPage;

  return fieldsInfos.length === 0
    ? undefined
    : fieldsInfos[fieldsInfos.length - 1].id;
},
```

## Issue Number

- Close #101 
