### PR TITLE
✨ feat: 매칭 상세 매칭탭 - API 연동

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -381,6 +381,9 @@ PODS:
     - React-Core
   - react-native-safe-area-context (4.7.1):
     - React-Core
+  - react-native-simple-toast (3.0.1):
+    - React-Core
+    - Toast (~> 4)
   - react-native-slider (4.4.2):
     - React-Core
   - React-NativeModulesApple (0.72.3):
@@ -505,6 +508,7 @@ PODS:
   - RNSVG (13.10.0):
     - React-Core
   - SocketRocket (0.6.1)
+  - Toast (4.0.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -558,6 +562,7 @@ DEPENDENCIES:
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - react-native-pager-view (from `../node_modules/react-native-pager-view`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - react-native-simple-toast (from `../node_modules/react-native-simple-toast`)
   - "react-native-slider (from `../node_modules/@react-native-community/slider`)"
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -598,6 +603,7 @@ SPEC REPOS:
     - libevent
     - OpenSSL-Universal
     - SocketRocket
+    - Toast
     - YogaKit
 
 EXTERNAL SOURCES:
@@ -650,6 +656,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-pager-view"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
+  react-native-simple-toast:
+    :path: "../node_modules/react-native-simple-toast"
   react-native-slider:
     :path: "../node_modules/@react-native-community/slider"
   React-NativeModulesApple:
@@ -736,6 +744,7 @@ SPEC CHECKSUMS:
   react-native-image-picker: 5fcac5a5ffcb3737837f0617d43fd767249290de
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
+  react-native-simple-toast: 0c7d14bcad288b5b83ae4b0eea65651b4ca829b0
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
   React-NativeModulesApple: c57f3efe0df288a6532b726ad2d0322a9bf38472
   React-perflogger: 6bd153e776e6beed54c56b0847e1220a3ff92ba5
@@ -760,6 +769,7 @@ SPEC CHECKSUMS:
   RNScreens: 6a8a3c6b808aa48dca1780df7b73ea524f602c63
   RNSVG: 80584470ff1ffc7994923ea135a3e5ad825546b9
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
+  Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-native-pager-view": "^6.2.0",
         "react-native-safe-area-context": "^4.7.1",
         "react-native-screens": "^3.23.0",
+        "react-native-simple-toast": "3.0.1",
         "react-native-svg": "13.10.0",
         "react-native-tab-view": "^3.5.2",
         "react-native-web": "^0.18.12",
@@ -28810,6 +28811,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-simple-toast": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-simple-toast/-/react-native-simple-toast-3.0.1.tgz",
+      "integrity": "sha512-G1iUHqvhA4Obacol+fz1MKTeHDGyDFGXvnmAxYrUNBkTOA9/yaVpZBjoWfpnYXIlYtrCOcz6ll/B8nUJg4PPDA==",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.71.0"
       }
     },
     "node_modules/react-native-svg": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-native-pager-view": "^6.2.0",
     "react-native-safe-area-context": "^4.7.1",
     "react-native-screens": "^3.23.0",
+    "react-native-simple-toast": "3.0.1",
     "react-native-svg": "13.10.0",
     "react-native-tab-view": "^3.5.2",
     "react-native-web": "^0.18.12",

--- a/src/features/match/components/MatchDetailMatching/MatchApplyHeader.tsx
+++ b/src/features/match/components/MatchDetailMatching/MatchApplyHeader.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+
+import {Text} from '../../../../components/Text';
+
+interface IMatchApplyHeaderProps {
+  type: 'RECEIVED' | 'SENT' | 'MATCHED';
+  settingIcon?: React.JSX.Element;
+}
+
+export const MatchApplyHeader = ({
+  type,
+  settingIcon,
+}: IMatchApplyHeaderProps): React.JSX.Element => {
+  const titleByType = {
+    RECEIVED: '요청받은 매칭',
+    SENT: '신청한 매칭',
+    MATCHED: '진행중인 매칭',
+  } as const;
+
+  return (
+    <StyledHeaderWrapper>
+      <Text type="head4" fontWeight="600" text={titleByType[type]} />
+      {settingIcon}
+    </StyledHeaderWrapper>
+  );
+};
+
+const StyledHeaderWrapper = styled.View`
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 32px 16px 20px 16px;
+`;

--- a/src/features/match/components/MatchDetailMatching/MatchApplyList.tsx
+++ b/src/features/match/components/MatchDetailMatching/MatchApplyList.tsx
@@ -1,146 +1,80 @@
-import React, {useState} from 'react';
+import React from 'react';
 
 import styled from '@emotion/native';
-import {ScrollView, TouchableOpacity, View} from 'react-native';
+import {type InfiniteData} from '@tanstack/react-query';
+import {FlatList} from 'react-native';
 
 import {MatchApplyListItem} from './MatchApplyListItem';
-import {arrowRightXmlData} from '../../../../assets/svg';
-import {Button} from '../../../../components/Button';
-import {Icon} from '../../../../components/Icon';
 import {Text} from '../../../../components/Text';
-import {type IMatchApply} from '../../types';
+import {type IBattleEntry} from '../../types';
 
 interface IMatchApplyListProps {
-  type: 'RECEIVED' | 'SENT' | 'MATCHED';
-  totalCount: number;
-  applies: IMatchApply[];
-  isSummary?: boolean;
-  onPressMore?: () => void;
-  onPressSettingConfirmButton?: () => void;
-  onPressTeamDetail: (matchId: number) => void;
+  type: 'RECEIVED' | 'SENT';
+  isSettingMode?: boolean;
+  fieldEntryBattleData?: InfiniteData<{
+    battleEntries: IBattleEntry[];
+    currentPageNumber: number;
+    currentPageSize: number;
+    totalCount: number;
+  }>;
+  checkedId?: number;
+  onPressTeamDetail: (fieldId: number) => void;
+  onPressCheckBox?: (entryId: number | undefined) => void;
+  onEndReached?: () => void;
 }
 
 export const MatchApplyList = ({
   type,
-  totalCount,
-  applies,
-  isSummary = true,
-  onPressMore,
-  onPressSettingConfirmButton = () => {},
+  isSettingMode = false,
+  fieldEntryBattleData,
+  checkedId = undefined,
   onPressTeamDetail,
+  onPressCheckBox = () => {},
+  onEndReached = () => {},
 }: IMatchApplyListProps): React.JSX.Element => {
-  const [isSettingMode, setIsSettingMode] = useState(false);
-  const [checkedApply, setCheckedApply] = useState<number[]>([]);
-  const [settingButtonText, setSettingButtonText] = useState('');
-
   const infoByType = {
     RECEIVED: '요청받은 매칭',
     SENT: '신청한 매칭',
-    MATCHED: '매칭된 팀',
   } as const;
 
-  const showAppliesData = isSummary ? applies.slice(0, 3) : applies;
-
-  const handleSettingList = (): void => {
-    if (type === 'SENT') {
-      setIsSettingMode(value => !value);
-      setCheckedApply([]);
-      setSettingButtonText('신청 취소');
-    } else if (type === 'RECEIVED') {
-      setIsSettingMode(value => !value);
-      setCheckedApply([]);
-      // TODO: 제거/수락 모드 선택하는 플로우 추가
-      setSettingButtonText('요청 수락');
-    }
-  };
-
   return (
-    <View style={{flex: 1}}>
-      <StyledHeaderWrapper>
-        <Text type="head4" fontWeight="600" text={infoByType[type]} />
-        <TouchableOpacity
-          activeOpacity={0.8}
-          onPress={isSummary ? onPressMore : handleSettingList}>
-          {isSummary ? (
-            <Icon svgXml={arrowRightXmlData} width={44} height={44} />
-          ) : (
-            <Text
-              type="body2"
-              color="gray-600"
-              fontWeight="400"
-              text={isSettingMode ? '설정취소' : '설정'}
-            />
-          )}
-        </TouchableOpacity>
-      </StyledHeaderWrapper>
-      <ScrollView>
-        {totalCount !== 0 ? (
-          showAppliesData.map((apply, idx) => (
-            <MatchApplyListItem
-              key={`${type}-${idx}`}
-              isSettingMode={isSettingMode}
-              apply={apply}
-              isCheck={checkedApply.includes(apply.entryId)}
-              onPressTeamDetail={onPressTeamDetail}
-              onPressCheckBox={() => {
-                checkedApply.includes(apply.entryId)
-                  ? setCheckedApply(value => [
-                      ...value.filter(id => id !== apply.entryId),
-                    ])
-                  : setCheckedApply(value => [...value, apply.entryId]);
-              }}
-            />
-          ))
-        ) : (
-          <StyledNoContentsWrapper>
-            <Text
-              type="body2"
-              color="gray-400"
-              fontWeight="600"
-              text={`${infoByType[type]}이 없습니다.`}
-            />
-          </StyledNoContentsWrapper>
-        )}
-      </ScrollView>
-
-      {isSummary && totalCount > 3 && (
-        <StyledButton onPress={onPressMore}>
-          <Text type="body2" color="gray-600" fontWeight="400" text="더보기" />
-        </StyledButton>
+    <FlatList
+      scrollEnabled={false}
+      data={fieldEntryBattleData?.pages.map(page => page.battleEntries).flat()}
+      keyExtractor={item => `field-entry-${item.fieldType}-${item.fieldId}`}
+      renderItem={({item}) => (
+        <MatchApplyListItem
+          key={`${type}-${item.fieldId}`}
+          isSettingMode={isSettingMode}
+          apply={item}
+          isCheck={item.entryId === checkedId}
+          onPressTeamDetail={onPressTeamDetail}
+          onPressCheckBox={() => {
+            item.entryId === checkedId
+              ? onPressCheckBox(undefined)
+              : onPressCheckBox(item.entryId);
+          }}
+        />
       )}
-
-      {!isSummary && isSettingMode && (
-        <View style={{position: 'absolute', bottom: 0, width: '100%'}}>
-          <Button
-            text={settingButtonText}
-            disabled={checkedApply.length === 0}
-            onPress={onPressSettingConfirmButton}
+      ListEmptyComponent={
+        <StyledNoContentsWrapper>
+          <Text
+            type="body2"
+            color="gray-400"
+            fontWeight="600"
+            text={`${infoByType[type]}이 없습니다.`}
           />
-        </View>
-      )}
-    </View>
+        </StyledNoContentsWrapper>
+      }
+      onEndReached={onEndReached}
+      onEndReachedThreshold={0.5}
+    />
   );
 };
-
-const StyledHeaderWrapper = styled.View`
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  padding: 32px 16px 20px 16px;
-`;
 
 const StyledNoContentsWrapper = styled.View`
   flex-direction: row;
   align-items: center;
   min-height: 120px;
   margin: 0px auto 30px auto;
-`;
-
-const StyledButton = styled.TouchableOpacity`
-  align-items: center;
-  margin: auto;
-  color: ${props => props.theme.palette['gray-600']};
-  background-color: ${props => props.theme.palette['gray-50']};
-  margin: 10px 17px 30px 17px;
-  padding: 27px 0px;
 `;

--- a/src/features/match/components/MatchDetailMatching/MatchApplyListItem.tsx
+++ b/src/features/match/components/MatchDetailMatching/MatchApplyListItem.tsx
@@ -8,13 +8,13 @@ import {Gap} from '../../../../components/Gap';
 import {Tags} from '../../../../components/Tag';
 import {Text} from '../../../../components/Text';
 import {FieldTypes, Periods, SkillLevels} from '../../const';
-import {type IMatchApply} from '../../types';
+import {type IBattleEntry} from '../../types';
 
 interface IMatchApplyListItemProps {
   isSettingMode?: boolean;
   isCheck?: boolean;
-  apply: IMatchApply;
-  onPressCheckBox?: () => void;
+  apply: IBattleEntry;
+  onPressCheckBox?: (entryId: number) => void;
   onPressTeamDetail: (matchId: number) => void;
 }
 
@@ -27,16 +27,16 @@ export const MatchApplyListItem = ({
   isSettingMode = false,
   isCheck = false,
   apply,
-  onPressCheckBox,
+  onPressCheckBox = () => {},
   onPressTeamDetail,
 }: IMatchApplyListItemProps): React.JSX.Element => {
   const {
+    currentSize,
     entryId,
-    matchId,
-    name,
-    memberCount,
-    memberMaxCount,
+    fieldId,
     fieldType,
+    maxSize,
+    name,
     period,
     skillLevel,
   } = apply;
@@ -47,13 +47,18 @@ export const MatchApplyListItem = ({
       isSettingMode={isSettingMode}
       isCheck={isCheck}>
       {isSettingMode && (
-        <CheckBox isCheck={isCheck} onPress={onPressCheckBox} />
+        <CheckBox
+          isCheck={isCheck}
+          onPress={() => {
+            onPressCheckBox(entryId);
+          }}
+        />
       )}
 
       <TouchableOpacity
         activeOpacity={0.8}
         onPress={() => {
-          if (!isSettingMode) onPressTeamDetail(matchId);
+          if (!isSettingMode) onPressTeamDetail(fieldId);
         }}>
         <Text type="body1" color="gray-700" fontWeight="600" text={name} />
         <Gap size="12px" />
@@ -61,7 +66,7 @@ export const MatchApplyListItem = ({
           type="body3"
           color="gray-700"
           fontWeight="700"
-          text={`팀원 모집 완료 ${memberCount.toString()}/${memberMaxCount.toString()}`}
+          text={`팀원 모집 완료 ${currentSize.toString()}/${maxSize.toString()}`}
         />
         <Gap size="10px" />
         <Tags

--- a/src/features/match/components/MatchDetailMatching/index.ts
+++ b/src/features/match/components/MatchDetailMatching/index.ts
@@ -1,2 +1,3 @@
 export * from './MatchApplyListItem';
 export * from './MatchApplyList';
+export * from './MatchApplyHeader';

--- a/src/features/match/hooks/fieldEntry/index.ts
+++ b/src/features/match/hooks/fieldEntry/index.ts
@@ -2,3 +2,6 @@
 // export * from './usePostFieldEntryTeam';
 export * from './useGetFieldEntryTeam';
 export * from './useGetInfiniteFieldEntry';
+export * from './useGetInfiniteFieldEntryBattleDetail';
+export * from './usePostFieldEntryAccept';
+export * from './useDeleteFieldEntry';

--- a/src/features/match/hooks/fieldEntry/keys.ts
+++ b/src/features/match/hooks/fieldEntry/keys.ts
@@ -12,6 +12,13 @@ interface IEntryProps {
   size: number;
 }
 
+interface IBattleProps {
+  id: number;
+  page: number;
+  size: number;
+  fieldDirection: 'RECEIVED' | 'SENT';
+}
+
 export const KEYS = {
   all: ['field-entry'] as const,
   fieldEntry: ({fieldType, page, size}: IFieldEntryProps) =>
@@ -24,7 +31,8 @@ export const KEYS = {
         size,
       },
     ] as const,
-  battle: (id: number) => [...KEYS.all, 'battle', id] as const,
+  battle: ({id, page, size, fieldDirection}: IBattleProps) =>
+    [...KEYS.all, 'battle', {id, page, size, fieldDirection}] as const,
   team: (id: number) => [...KEYS.all, 'team', id] as const,
   entry: ({id, page, size}: IEntryProps) =>
     [

--- a/src/features/match/hooks/fieldEntry/useDeleteFieldEntry.ts
+++ b/src/features/match/hooks/fieldEntry/useDeleteFieldEntry.ts
@@ -4,31 +4,25 @@ import {type AxiosError} from 'axios';
 import {KEYS} from './keys';
 import {axios} from '../../../../lib/axios';
 import {queryClient} from '../../../../lib/react-query';
-import {KEYS as FIELD_KEYS} from '../field/keys';
 
 interface IProps {
   entryId: number;
 }
 
-interface IUsePostFieldEntryAcceptProps {
+interface IUseDeleteFieldEntryProps {
   onSuccessCallback?: () => void;
 }
 
 const fetcher = async ({entryId}: IProps): Promise<string> =>
-  await axios.post(`/field-entry/${entryId}/accept`).then(({data}) => data);
+  await axios.delete(`/field-entry/${entryId}`).then(({data}) => data);
 
-export const usePostFieldEntryAccept = ({
+export const useDeleteFieldEntry = ({
   onSuccessCallback = () => {},
-}: IUsePostFieldEntryAcceptProps): UseMutationResult<
-  string,
-  AxiosError,
-  IProps
-> =>
+}: IUseDeleteFieldEntryProps): UseMutationResult<string, AxiosError, IProps> =>
   useMutation({
     mutationFn: fetcher,
     onSuccess: () => {
       onSuccessCallback();
       void queryClient.invalidateQueries(KEYS.all);
-      void queryClient.fetchInfiniteQuery(FIELD_KEYS.all);
     },
   });

--- a/src/features/match/hooks/fieldEntry/useGetInfiniteFieldEntryBattleDetail.ts
+++ b/src/features/match/hooks/fieldEntry/useGetInfiniteFieldEntryBattleDetail.ts
@@ -1,0 +1,78 @@
+import {
+  useInfiniteQuery,
+  type UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {axios} from '../../../../lib/axios';
+import {type IBattleEntry} from '../../types';
+
+interface IProps {
+  id: number;
+  page: number;
+  size: number;
+  fieldDirection: 'RECEIVED' | 'SENT';
+}
+
+interface IFieldEntryBattle {
+  battleEntries: IBattleEntry[];
+  currentPageNumber: number;
+  currentPageSize: number;
+  totalCount: number;
+}
+
+const fetcher = async ({
+  id,
+  page,
+  size,
+  fieldDirection,
+}: IProps): Promise<IFieldEntryBattle> =>
+  await axios
+    .get(`/field-entry/battle/${id}`, {
+      params: {
+        page,
+        size,
+        fieldDirection,
+      },
+    })
+    .then(({data}) => data);
+
+export const useGetInfiniteFieldEntryBattleDetail = ({
+  id,
+  page,
+  size,
+  fieldDirection,
+}: IProps): UseInfiniteQueryResult<IFieldEntryBattle, Error> =>
+  useInfiniteQuery({
+    queryKey: KEYS.battle({id, page, size, fieldDirection}),
+    queryFn: async ({pageParam = 0}) =>
+      await fetcher({
+        id,
+        size,
+        page: pageParam,
+        fieldDirection,
+      }),
+    getNextPageParam: lastPage => {
+      const {currentPageNumber, currentPageSize, totalCount, battleEntries} =
+        lastPage;
+
+      const currentDataCount =
+        currentPageNumber > 0
+          ? (currentPageNumber - 1) * currentPageSize + battleEntries.length
+          : battleEntries.length;
+      const nextPage = currentPageNumber + 1;
+
+      return totalCount > currentDataCount ? nextPage : undefined;
+    },
+    initialData: {
+      pageParams: [],
+      pages: [
+        {
+          battleEntries: [],
+          totalCount: 0,
+          currentPageNumber: 0,
+          currentPageSize: 0,
+        },
+      ],
+    },
+  });

--- a/src/navigators/MatchNavigator.tsx
+++ b/src/navigators/MatchNavigator.tsx
@@ -43,6 +43,7 @@ export type MatchStackParamList = {
   MatchDetailMatchingMore: {
     id: number;
     type: 'RECEIVED' | 'SENT';
+    userRole: TUserRole;
   };
   MatchDetailMemberMore: {
     id: number;

--- a/src/navigators/MatchNavigator.tsx
+++ b/src/navigators/MatchNavigator.tsx
@@ -14,13 +14,9 @@ import {
   CreateMatchProfileScreen,
 } from '../screens/match/create';
 import {
-  MatchDetailMatchingMoreScreen,
-  MatchDetailMatchingScreen,
-  MatchDetailMemberScreen,
-  MatchDetailProfileScreen,
-  MatchDetailRecordDetailScreen,
-  MatchDetailRecordScreen,
   MatchDetailScreen,
+  MatchDetailMatchingMoreScreen,
+  MatchDetailRecordDetailScreen,
   MatchDetailMemberRequestAcceptScreen,
 } from '../screens/match/detail';
 import {
@@ -43,16 +39,11 @@ export type MatchStackParamList = {
   MatchDetail: {
     id: number;
   };
-  MatchDetailProfile: {
-    id: number;
-  };
-  MatchDetailRecord: undefined;
   MatchDetailRecordDetail: IMatchDetailRecord;
-  MatchDetailMatching: undefined;
   MatchDetailMatchingMore: {
+    id: number;
     type: 'RECEIVED' | 'SENT';
   };
-  MatchDetailMember: undefined;
   MatchDetailMemberMore: {
     id: number;
     userRole: TUserRole;
@@ -118,33 +109,13 @@ export function MatchNavigator(): React.JSX.Element {
         options={{headerTitle: ''}}
       />
       <Stack.Screen
-        name="MatchDetailProfile"
-        component={MatchDetailProfileScreen}
-        options={{headerTitle: ''}}
-      />
-      <Stack.Screen
-        name="MatchDetailRecord"
-        component={MatchDetailRecordScreen}
-        options={{headerTitle: ''}}
-      />
-      <Stack.Screen
         name="MatchDetailRecordDetail"
         component={MatchDetailRecordDetailScreen}
         options={{headerTitle: ''}}
       />
       <Stack.Screen
-        name="MatchDetailMatching"
-        component={MatchDetailMatchingScreen}
-        options={{headerTitle: ''}}
-      />
-      <Stack.Screen
         name="MatchDetailMatchingMore"
         component={MatchDetailMatchingMoreScreen}
-        options={{headerTitle: ''}}
-      />
-      <Stack.Screen
-        name="MatchDetailMember"
-        component={MatchDetailMemberScreen}
         options={{headerTitle: ''}}
       />
       <Stack.Screen
@@ -170,10 +141,6 @@ export function MatchNavigator(): React.JSX.Element {
         component={MatchDetailMemberDeleteScreen}
         options={{headerTitle: ''}}
       />
-      {/* TODO: 하위 스크린 MatchNavigator 에 셋팅 */}
-      {/* 팀 상세 관련 스크린 (설정, 현재 팀원, 정보 수정, 프로필 수정, 알림, 기록보기, 매칭된 팀 프로필, 신청한 상대팀, 요청받은 상대팀, 방장 넘기기, 팀원 삭제, 요청 ...) */}
-      {/* 자동 매칭 선택 스크린 */}
-      {/* 자동 매칭 스크린 */}
     </Stack.Navigator>
   );
 }

--- a/src/screens/match/detail/MatchDetailScreen.tsx
+++ b/src/screens/match/detail/MatchDetailScreen.tsx
@@ -71,6 +71,7 @@ export const MatchDetailScreen = ({
               <MatchDetailMatchingScreen
                 id={id}
                 assignedField={fieldDetailData?.assignedFieldDto}
+                userRole={fieldDetailData?.fieldDto?.fieldRole}
               />
             ),
           },

--- a/src/screens/match/detail/MatchDetailScreen.tsx
+++ b/src/screens/match/detail/MatchDetailScreen.tsx
@@ -67,7 +67,12 @@ export const MatchDetailScreen = ({
           {
             name: 'TeamMatching',
             label: '매칭',
-            component: MatchDetailMatchingScreen,
+            component: () => (
+              <MatchDetailMatchingScreen
+                id={id}
+                assignedField={fieldDetailData?.assignedFieldDto}
+              />
+            ),
           },
           {
             name: 'TeamMember',

--- a/src/screens/match/detail/matching/MatchDetailMatchingMoreScreen.tsx
+++ b/src/screens/match/detail/matching/MatchDetailMatchingMoreScreen.tsx
@@ -34,7 +34,7 @@ export const MatchDetailMatchingMoreScreen = (): React.JSX.Element => {
   const navigation =
     useNavigation<NativeStackNavigationProp<MatchStackParamList>>();
 
-  const {id, type} = route.params;
+  const {id, type, userRole = 'GUEST'} = route.params;
 
   const {
     data: fieldEntryBattleData,
@@ -123,16 +123,18 @@ export const MatchDetailMatchingMoreScreen = (): React.JSX.Element => {
     <SafeAreaView style={{flex: 1, backgroundColor: theme.palette['gray-0']}}>
       <MatchApplyHeader
         type={type}
-        settingIcon={
-          <TouchableOpacity activeOpacity={0.8} onPress={handleSettingList}>
-            <Text
-              type="body2"
-              color="gray-600"
-              fontWeight="400"
-              text={isSettingMode ? '설정취소' : '설정'}
-            />
-          </TouchableOpacity>
-        }
+        {...(userRole === 'LEADER' && {
+          settingIcon: (
+            <TouchableOpacity activeOpacity={0.8} onPress={handleSettingList}>
+              <Text
+                type="body2"
+                color="gray-600"
+                fontWeight="400"
+                text={isSettingMode ? '설정취소' : '설정'}
+              />
+            </TouchableOpacity>
+          ),
+        })}
       />
 
       <MatchApplyList

--- a/src/screens/match/detail/matching/MatchDetailMatchingScreen.tsx
+++ b/src/screens/match/detail/matching/MatchDetailMatchingScreen.tsx
@@ -16,17 +16,19 @@ import {
   MatchApplyHeader,
 } from '../../../../features/match/components/MatchDetailMatching';
 import {useGetInfiniteFieldEntryBattleDetail} from '../../../../features/match/hooks/fieldEntry';
-import {type IField} from '../../../../features/match/types';
+import {type TUserRole, type IField} from '../../../../features/match/types';
 import {type MatchStackParamList} from '../../../../navigators/MatchNavigator';
 
 interface IMatchDetailMatchingScreenProps {
   id: number;
   assignedField: IField;
+  userRole: TUserRole;
 }
 
 export const MatchDetailMatchingScreen = ({
   id,
   assignedField,
+  userRole,
 }: IMatchDetailMatchingScreenProps): React.JSX.Element => {
   const navigation =
     useNavigation<NativeStackNavigationProp<MatchStackParamList>>();
@@ -65,7 +67,7 @@ export const MatchDetailMatchingScreen = ({
       : 0;
 
   const handleMoreMatch = (type: 'SENT' | 'RECEIVED'): void => {
-    navigation.navigate('MatchDetailMatchingMore', {id, type});
+    navigation.navigate('MatchDetailMatchingMore', {id, type, userRole});
   };
 
   const handleTeamDetail = (matchId: number): void => {

--- a/src/screens/match/detail/matching/MatchDetailMatchingScreen.tsx
+++ b/src/screens/match/detail/matching/MatchDetailMatchingScreen.tsx
@@ -1,70 +1,163 @@
 import React from 'react';
 
-import {type NativeStackScreenProps} from '@react-navigation/native-stack';
-import {SafeAreaView, ScrollView} from 'react-native';
+import styled from '@emotion/native';
+import {useNavigation} from '@react-navigation/native';
+import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {SafeAreaView, ScrollView, TouchableOpacity} from 'react-native';
 
 import {theme} from '../../../../assets/styles/theme';
+import {arrowRightXmlData} from '../../../../assets/svg';
+import {Icon} from '../../../../components/Icon';
 import {Line} from '../../../../components/Line';
-import {MatchApplyList} from '../../../../features/match/components/MatchDetailMatching';
+import {ListItem} from '../../../../components/List';
+import {Text} from '../../../../components/Text';
 import {
-  APPLY_DUMMY_DATA,
-  SENT_DUMMY_DATA,
-  useGetFieldDetailEntryBattle,
-} from '../../../../features/match/hooks/field/useGetFieldDetailEntryBattle';
+  MatchApplyList,
+  MatchApplyHeader,
+} from '../../../../features/match/components/MatchDetailMatching';
+import {useGetInfiniteFieldEntryBattleDetail} from '../../../../features/match/hooks/fieldEntry';
+import {type IField} from '../../../../features/match/types';
 import {type MatchStackParamList} from '../../../../navigators/MatchNavigator';
 
-type TMatchDetailMatchingScreenProps = NativeStackScreenProps<
-  MatchStackParamList,
-  'MatchDetailMatching'
->;
+interface IMatchDetailMatchingScreenProps {
+  id: number;
+  assignedField: IField;
+}
 
 export const MatchDetailMatchingScreen = ({
-  navigation,
-}: TMatchDetailMatchingScreenProps): React.JSX.Element => {
-  const selectMatchId = 1;
+  id,
+  assignedField,
+}: IMatchDetailMatchingScreenProps): React.JSX.Element => {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<MatchStackParamList>>();
 
-  const {data: sentData = SENT_DUMMY_DATA} = useGetFieldDetailEntryBattle({
-    id: selectMatchId,
+  const {
+    data: sentFieldEntryBattleData,
+    isLoading: isLoadingSentFieldEntryBattle,
+  } = useGetInfiniteFieldEntryBattleDetail({
+    id,
+    page: 0,
+    size: 3,
     fieldDirection: 'SENT',
   });
 
-  const {data: receivedData = APPLY_DUMMY_DATA} = useGetFieldDetailEntryBattle({
-    id: selectMatchId,
+  const {
+    data: receivedFieldEntryBattleData,
+    isLoading: isLoadingReceivedFieldEntryBattle,
+  } = useGetInfiniteFieldEntryBattleDetail({
+    id,
+    page: 0,
+    size: 3,
     fieldDirection: 'RECEIVED',
   });
 
+  if (isLoadingSentFieldEntryBattle || isLoadingReceivedFieldEntryBattle)
+    return <></>;
+
+  const sentFieldLength =
+    sentFieldEntryBattleData?.pages != null
+      ? sentFieldEntryBattleData?.pages[0]?.totalCount
+      : 0;
+
+  const receivedFieldLength =
+    receivedFieldEntryBattleData?.pages != null
+      ? receivedFieldEntryBattleData?.pages[0]?.totalCount
+      : 0;
+
   const handleMoreMatch = (type: 'SENT' | 'RECEIVED'): void => {
-    navigation.navigate('MatchDetailMatchingMore', {type});
+    navigation.navigate('MatchDetailMatchingMore', {id, type});
   };
 
   const handleTeamDetail = (matchId: number): void => {
-    navigation.navigate('MatchDetailProfile', {id: matchId});
+    navigation.push('MatchDetail', {id: matchId});
   };
 
   return (
     <SafeAreaView
       style={{backgroundColor: theme.palette['gray-0'], height: '100%'}}>
       <ScrollView>
-        <MatchApplyList
-          type="SENT"
-          totalCount={sentData.totalCount}
-          applies={sentData.fieldEntriesInfos}
-          onPressMore={() => {
-            handleMoreMatch('SENT');
-          }}
-          onPressTeamDetail={handleTeamDetail}
-        />
-        <Line size="lg" />
-        <MatchApplyList
-          type="RECEIVED"
-          totalCount={receivedData.totalCount}
-          applies={receivedData.fieldEntriesInfos}
-          onPressMore={() => {
-            handleMoreMatch('RECEIVED');
-          }}
-          onPressTeamDetail={handleTeamDetail}
-        />
+        {assignedField !== null ? (
+          <>
+            <MatchApplyHeader type="MATCHED" />
+            <ListItem {...assignedField} />
+          </>
+        ) : (
+          <>
+            <MatchApplyHeader
+              type="SENT"
+              settingIcon={
+                <TouchableOpacity
+                  activeOpacity={0.8}
+                  onPress={() => {
+                    handleMoreMatch('SENT');
+                  }}>
+                  <Icon svgXml={arrowRightXmlData} width={44} height={44} />
+                </TouchableOpacity>
+              }
+            />
+            <MatchApplyList
+              type="SENT"
+              fieldEntryBattleData={sentFieldEntryBattleData}
+              onPressTeamDetail={handleTeamDetail}
+            />
+            {sentFieldLength > 3 && (
+              <StyledButton
+                onPress={() => {
+                  handleMoreMatch('SENT');
+                }}>
+                <Text
+                  type="body2"
+                  color="gray-600"
+                  fontWeight="400"
+                  text="더보기"
+                />
+              </StyledButton>
+            )}
+
+            <Line size="lg" />
+
+            <MatchApplyHeader
+              type="RECEIVED"
+              settingIcon={
+                <TouchableOpacity
+                  activeOpacity={0.8}
+                  onPress={() => {
+                    handleMoreMatch('RECEIVED');
+                  }}>
+                  <Icon svgXml={arrowRightXmlData} width={44} height={44} />
+                </TouchableOpacity>
+              }
+            />
+            <MatchApplyList
+              type="RECEIVED"
+              fieldEntryBattleData={receivedFieldEntryBattleData}
+              onPressTeamDetail={handleTeamDetail}
+            />
+            {receivedFieldLength > 3 && (
+              <StyledButton
+                onPress={() => {
+                  handleMoreMatch('RECEIVED');
+                }}>
+                <Text
+                  type="body2"
+                  color="gray-600"
+                  fontWeight="400"
+                  text="더보기"
+                />
+              </StyledButton>
+            )}
+          </>
+        )}
       </ScrollView>
     </SafeAreaView>
   );
 };
+
+const StyledButton = styled.TouchableOpacity`
+  align-items: center;
+  margin: auto;
+  color: ${props => props.theme.palette['gray-600']};
+  background-color: ${props => props.theme.palette['gray-50']};
+  margin: 10px 17px 30px 17px;
+  padding: 27px 0px;
+`;


### PR DESCRIPTION
## branch

- `main` <- `feature/detail-matching`

## Summary

- 매칭 상세 매칭탭에 대한 feature 컴포넌트를 리팩토링 하고, API 연동 작업을 진행하였습니다.

| 매칭탭 목록 | 신청한 매칭 상세 | 신청한 매칭 상세 설정모드 | 신청 취소 선택 후 모달 | 
|--------|--------|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-26 at 17 02 17](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/ad033638-543a-4a61-a1a4-656d7c8cab91) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-26 at 17 02 24](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/2298b49d-d644-441d-9b04-996e0658a179) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-26 at 17 02 27](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/dfad3d37-f75a-465a-b7ee-31658da598c1) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-26 at 17 02 32](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/8e36b5db-a716-4263-b4fc-401c04490d1a) | 

| 신청 취소 완료 | 요청받은 매칭 상세 설정모드 | 요청 수락 선택 후 모달 | 매칭 수락 완료 (노출 데이터 수정 필요) |
|--------|--------|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-26 at 17 02 37](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/76b8aa12-dc29-4405-90d6-669ee6adfa03) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-26 at 17 02 48](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/a4324a8e-6867-4af0-84e7-4b398e062428) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-26 at 17 04 47](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/e62664e1-769f-4cb3-9efc-c6f451ac7ba8) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-09-26 at 17 04 52](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/6a3544db-4158-456d-8f9a-fda778d3621c) | 


## Task

- [x] react-native-simple-toast 라이브러리 추가

- [x] MatchApplyList, MatchApplyList 컴포넌트 리팩토링

  - [x] 무한 스크롤 방식을 적용하기 위해 `FlatList` 활용 
  - [x] MatchApplyHeader 컴포넌트 분리
  - [x] 매칭에 대한 userRole에 따라 설정 버튼 노출 기능 추가 

- [x] MatchNavigator 리팩토링

  - [x] 매칭 상세에 포함되는 탭 화면들이 `MatchDetailScreen` 내의 탭에서 사용되고 있기 때문에, navigator 셋팅이 불필요하다고 판단되어 제거

- [x] 매칭 상세 매칭탭 관련 API 연동

  - [x] 매칭 신청/요청 리스트 불러오기 useGetInfiniteFieldEntryBattleDetail
  - [x] 매칭 신청 취소 useDeleteFieldEntry
  - [x] 매칭 수락 usePostFieldEntryAccept

## ETC

- mutate onSuccess 상태에서 활용하기 위해 toast 라이브러리를 추가하였습니다. 
- 매칭된 매칭/신청한 매칭 및 요청받은 매칭을 구분하기 위해 `GET /field/${id}` 이 보내주는 `assignedFieldDto === null` 체크를 활용하고 있습니다. 매칭 수락 API는 정상동작이 되나,  `GET /field/${id}` 가 보내주는 데이터에 반영이 안된 것 같아  반영되는 시점 정책을 검토한 후 머지가 진행되어야할 것 같습니다. [문의 내용](https://www.notion.so/seonhye0113/field-entry-id-accept-cc64f161845d473a9d0c4dbbda77d469?pvs=4) 검토 이후, PR 생성해놓겠습니다.
  - 매칭 수락 후 자정 이후에 매칭이 시작되는데, 해당 기간 동안 `assignedFieldDto === null` 이었으나, 값을 넣어주기로 결정하였습니다!

## Issue Number

- Close #93 
