### PR TITLE
✨ feat: 매칭 상세 프로필탭 - 매칭 신청 및 팀원 신청 API 연동

### DIFF
--- a/src/features/match/hooks/fieldEntry/index.ts
+++ b/src/features/match/hooks/fieldEntry/index.ts
@@ -1,5 +1,5 @@
-// export * from './usePostFieldEntryBattle';
-// export * from './usePostFieldEntryTeam';
+export * from './usePostFieldEntryBattle';
+export * from './usePostFieldEntryTeam';
 export * from './useGetFieldEntryTeam';
 export * from './useGetInfiniteFieldEntry';
 export * from './useGetInfiniteFieldEntryBattleDetail';

--- a/src/features/match/hooks/fieldEntry/usePostFieldEntryBattle.ts
+++ b/src/features/match/hooks/fieldEntry/usePostFieldEntryBattle.ts
@@ -1,0 +1,40 @@
+import {type UseMutationResult, useMutation} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {axios} from '../../../../lib/axios';
+import {queryClient} from '../../../../lib/react-query';
+import {type CustomAxiosError} from '../../../../utils/types';
+import {type IFieldEntryBattle} from '../../types/fieldEntry';
+
+interface IProps {
+  body: IFieldEntryBattle;
+}
+
+interface IUsePostFieldEntryBattleProps {
+  onSuccessCallback: () => void;
+  onErrorCallback: (error: CustomAxiosError) => void;
+}
+
+const fetcher = async ({body}: IProps): Promise<string> =>
+  await axios.post('/field-entry/battle', body).then(({data}) => data);
+
+/** POST: 1:1배틀 혹은 팀배틀 신청 */
+export const usePostFieldEntryBattle = ({
+  onSuccessCallback,
+  onErrorCallback,
+}: IUsePostFieldEntryBattleProps): UseMutationResult<
+  string,
+  CustomAxiosError,
+  IProps
+> => {
+  return useMutation({
+    mutationFn: fetcher,
+    onSuccess: () => {
+      onSuccessCallback();
+      void queryClient.invalidateQueries(KEYS.all);
+    },
+    onError: error => {
+      onErrorCallback(error);
+    },
+  });
+};

--- a/src/features/match/hooks/fieldEntry/usePostFieldEntryTeam.ts
+++ b/src/features/match/hooks/fieldEntry/usePostFieldEntryTeam.ts
@@ -1,0 +1,40 @@
+import {type UseMutationResult, useMutation} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {axios} from '../../../../lib/axios';
+import {queryClient} from '../../../../lib/react-query';
+import {type CustomAxiosError} from '../../../../utils/types';
+import {type IFieldEntryTeam} from '../../types/fieldEntry';
+
+interface IProps {
+  body: IFieldEntryTeam;
+}
+
+interface IUsePostFieldEntryTeamProps {
+  onSuccessCallback: () => void;
+  onErrorCallback: (error: CustomAxiosError) => void;
+}
+
+/** POST: 팀 또는 팀배틀 입장 신청 */
+const fetcher = async ({body}: IProps): Promise<string> =>
+  await axios.post('/field-entry/team', body).then(({data}) => data);
+
+export const usePostFieldEntryTeam = ({
+  onSuccessCallback,
+  onErrorCallback,
+}: IUsePostFieldEntryTeamProps): UseMutationResult<
+  string,
+  CustomAxiosError,
+  IProps
+> => {
+  return useMutation({
+    mutationFn: fetcher,
+    onSuccess: () => {
+      onSuccessCallback();
+      void queryClient.invalidateQueries(KEYS.all);
+    },
+    onError: error => {
+      onErrorCallback(error);
+    },
+  });
+};

--- a/src/screens/match/detail/MatchDetailProfileScreen.tsx
+++ b/src/screens/match/detail/MatchDetailProfileScreen.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 
 import {SafeAreaView, ScrollView} from 'react-native';
+import Toast from 'react-native-simple-toast';
 
 import {theme} from '../../../assets/styles/theme';
 import {Button} from '../../../components/Button';
@@ -10,10 +11,10 @@ import {
   MatchDetailProfileSection,
   MatchDetailMembers,
 } from '../../../features/match/components/MatchDetailProfile';
-// import {
-//   usePostFieldEntryBattle,
-//   usePostFieldEntryTeam,
-// } from '../../../features/match/hooks/fieldEntry';
+import {
+  usePostFieldEntryBattle,
+  usePostFieldEntryTeam,
+} from '../../../features/match/hooks/fieldEntry';
 import {useGetUserFieldList} from '../../../features/match/hooks/userField';
 import {type IFieldDetailInfo} from '../../../features/match/types';
 
@@ -30,22 +31,43 @@ export const MatchDetailProfileScreen = ({
     subTitle: '',
   });
 
-  const {assignedFieldDto} = fieldDetailData;
-
   const {id, fieldType, fieldStatus, fieldRole, maxSize, currentSize} =
     fieldDetailData?.fieldDto;
 
   const {data: userListData} = useGetUserFieldList({id});
 
-  // const {mutate: mutateFieldEntryTeam} = usePostFieldEntryTeam({
-  //   openModal: setModalInfo,
-  // });
+  const {mutate: mutateFieldEntryTeam} = usePostFieldEntryTeam({
+    onSuccessCallback: () => {
+      Toast.show('팀원 신청이 완료되었습니다.', Toast.SHORT, {
+        backgroundColor: '#000000c5',
+      });
+    },
+    onErrorCallback: error => {
+      setModalInfo({
+        isVisible: true,
+        title: error?.response?.data?.message ?? '오류가 발생하였습니다',
+        subTitle: '다시 한 번 확인해주세요.',
+      });
+    },
+  });
 
-  // const {mutate: mutateFieldEntryBattle} = usePostFieldEntryBattle({
-  //   openModal: setModalInfo,
-  // });
+  const {mutate: mutateFieldEntryBattle} = usePostFieldEntryBattle({
+    onSuccessCallback: () => {
+      Toast.show('매칭 신청이 완료되었습니다.', Toast.SHORT, {
+        backgroundColor: '#000000c5',
+      });
+    },
+    onErrorCallback: error => {
+      setModalInfo({
+        isVisible: true,
+        title: error?.response?.data?.message ?? '오류가 발생하였습니다',
+        subTitle: '다시 한 번 확인해주세요.',
+      });
+    },
+  });
 
   const isAbleApplyMatchMember =
+    fieldType !== 'DUEL' &&
     fieldStatus === 'RECRUITING' &&
     maxSize !== currentSize &&
     fieldRole === 'GUEST';
@@ -53,18 +75,18 @@ export const MatchDetailProfileScreen = ({
   const isAbleApplyMatching =
     fieldType !== 'TEAM' &&
     fieldStatus === 'RECRUITING' &&
-    assignedFieldDto === null &&
+    fieldDetailData?.assignedFieldDto === null &&
     maxSize === currentSize &&
     fieldRole === 'GUEST';
 
   const handleApplyMember = (): void => {
-    // const body = {targetFieldId: id, teamType: fieldType};
-    // mutateFieldEntryTeam({body});
+    const body = {targetFieldId: id, teamType: fieldType};
+    mutateFieldEntryTeam({body});
   };
 
   const handleApplyMatching = (): void => {
-    // const body = {targetFieldId: id, battleType: fieldType};
-    // mutateFieldEntryBattle({body});
+    const body = {targetFieldId: id, battleType: fieldType};
+    mutateFieldEntryBattle({body});
   };
 
   return (

--- a/src/screens/match/detail/MatchDetailScreen.tsx
+++ b/src/screens/match/detail/MatchDetailScreen.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import styled from '@emotion/native';
 import {type RouteProp, useRoute} from '@react-navigation/native';
-import {type NativeStackScreenProps} from '@react-navigation/native-stack';
 import {SafeAreaView, View} from 'react-native';
 
 import {MatchDetailProfileScreen} from './MatchDetailProfileScreen';
@@ -18,19 +17,12 @@ import {
 import {useGetFieldDetail} from '../../../features/match/hooks/field';
 import {type MatchStackParamList} from '../../../navigators/MatchNavigator';
 
-type TMatchDetailScreenProps = NativeStackScreenProps<
-  MatchStackParamList,
-  'MatchDetail'
->;
-
 type TMatchDetailScreenRouteProps = RouteProp<
   MatchStackParamList,
   'MatchDetail'
 >;
 
-export const MatchDetailScreen = ({
-  navigation,
-}: TMatchDetailScreenProps): React.JSX.Element => {
+export const MatchDetailScreen = (): React.JSX.Element => {
   const route = useRoute<TMatchDetailScreenRouteProps>();
   const {id} = route.params;
 
@@ -101,7 +93,11 @@ export const MatchDetailScreen = ({
     <>
       <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}}>
         <StyledHeaderWrapper>
-          <Text type="head3" fontWeight="700" text="팀" />
+          <Text
+            type="head3"
+            fontWeight="700"
+            text={fieldDetailData.fieldDto.fieldType === 'DUEL' ? '1vs1' : '팀'}
+          />
         </StyledHeaderWrapper>
       </SafeAreaView>
       <TopTabNavigator size="sm" screens={screens} />

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,5 @@
+import {type AxiosError} from 'axios';
+
 export type ValueOf<T> = T[keyof T];
 
 export type Entries<T> = Array<
@@ -5,3 +7,11 @@ export type Entries<T> = Array<
     [K in keyof T]: [K, T[K]];
   }[keyof T]
 >;
+
+export interface CustomAxiosError
+  extends AxiosError<{
+    code: string;
+    errors: any[];
+    message: string;
+    status: string;
+  }> {}


### PR DESCRIPTION
## branch

- `main` <- `feature/match-apply`

## Summary

- 매칭 상세 프로필 탭에서 매칭 신청 및 팀원 신청 API 연동하였습니다.

| 팀원 신청 성공 | 팀원 신청 오류 (서버 메시지 수정될 예정) | 매칭 신청 화면 | 팀원 신청 화면 |
|--------|--------|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-06 at 22 25 04](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/803ecbed-f6b7-432a-86eb-fd544f3067de) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-05 at 22 49 51](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/0052af17-d509-4106-9a44-d719c713c52e) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-05 at 22 46 59](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/fcbc17b7-eae4-439b-94ad-c8b108cff9a2) |  ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-05 at 22 47 21](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/2af3140e-07fe-454e-a501-e8cb748d46d4) |



## Task

- [x] 매칭신청 usePostFieldEntryBattle API 연동

  - [x] 성공시, toast 노출
  - [x] 실패시, 서버 에러 메시지 modal 노출

- [x] 팀신청 usePostFieldEntryTeam API 연동

  - [x] 성공시, toast 노출
  - [x] 실패시, 서버 에러 메시지 modal 노출

- [x] fieldType 에 따른 매칭 상세 타이틀 변경

- [x] CustomAxiosError 타입 셋팅



## Issue Number

- Close #13 
