### PR TITLE
✨ feat: 홈(메인)스크린 내 '매칭 탭' 요약 보기 기능 구현

### DIFF
--- a/src/features/home/components/MatchPreviewSection/MatchPreviewSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchPreviewSection.tsx
@@ -1,0 +1,102 @@
+import React, {useState} from 'react';
+
+import {Animated, Dimensions, View} from 'react-native';
+
+import {MatchingPreviewDuelBattleSection} from './MatchingPreviewDuelBattleSection';
+import {MatchingPreviewTeamBattleSection} from './MatchingPreviewTeamBattleSection';
+import {MatchingPreviewTeamSection} from './MatchingPreviewTeamSection';
+import {Tab, TabContent} from './Tab';
+
+const {width} = Dimensions.get('window');
+
+export const MatchPreviewSection = (): React.JSX.Element => {
+  const [activeTab, setActiveTab] = useState<number>(0);
+  const [translateX] = useState(new Animated.Value(0));
+  const [translateXTabOne] = useState(new Animated.Value(0));
+  const [translateXTabTwo] = useState(new Animated.Value(width));
+  const [translateXTabThree] = useState(new Animated.Value(width * 2));
+
+  const handleSlide = (type: number): void => {
+    Animated.spring(translateX, {
+      toValue: type,
+      useNativeDriver: false,
+    }).start();
+
+    const tabOne = Animated.spring(translateXTabOne, {
+      toValue: type === 0 ? 0 : -width,
+      useNativeDriver: false,
+    });
+
+    const tabTwo = Animated.spring(translateXTabTwo, {
+      toValue: type === 1 ? 0 : type === 2 ? -width : width,
+      useNativeDriver: false,
+    });
+
+    const tabThree = Animated.spring(translateXTabThree, {
+      toValue: type === 2 ? 0 : width * 2,
+      useNativeDriver: false,
+    });
+
+    Animated.parallel([tabOne, tabTwo, tabThree]).start();
+  };
+
+  const tabs = [
+    {
+      title: '1:1 매칭',
+      tabContent: () => (
+        <TabContent translateXTab={translateXTabOne}>
+          <MatchingPreviewDuelBattleSection />
+        </TabContent>
+      ),
+    },
+    {
+      title: '팀 매칭',
+      tabContent: () => (
+        <TabContent translateXTab={translateXTabTwo} translateY={-300}>
+          <MatchingPreviewTeamBattleSection />
+        </TabContent>
+      ),
+    },
+    {
+      title: '매칭안함',
+      tabContent: () => (
+        <TabContent translateXTab={translateXTabThree} translateY={-600}>
+          <MatchingPreviewTeamSection />
+        </TabContent>
+      ),
+    },
+  ];
+
+  return (
+    <View style={{flex: 1}}>
+      <View style={{width: '90%', marginLeft: 'auto', marginRight: 'auto'}}>
+        <View
+          style={{
+            flexDirection: 'row',
+            marginTop: 40,
+            marginBottom: 20,
+            height: 36,
+            position: 'relative',
+          }}>
+          {tabs.map((tab, index) => (
+            <Tab
+              key={index}
+              title={tab.title}
+              active={activeTab === index}
+              onPress={() => {
+                setActiveTab(index);
+                handleSlide(index);
+              }}
+            />
+          ))}
+        </View>
+
+        <View style={{height: 320}}>
+          {tabs.map((tab, index) => (
+            <React.Fragment key={index}>{tab.tabContent()}</React.Fragment>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+};

--- a/src/features/home/components/MatchPreviewSection/MatchingBar.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingBar.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+import {type ViewProps} from 'react-native';
+
+import {Text} from '../../../../components/Text';
+
+interface IMatchingBarProps extends ViewProps {
+  leftName: string;
+  leftValue: number;
+  rightName: string;
+  rightValue: number;
+}
+
+export const MatchingBar = ({
+  leftName,
+  leftValue,
+  rightName,
+  rightValue,
+  ...props
+}: IMatchingBarProps): React.JSX.Element => {
+  const leftPercent = (leftValue / (leftValue + rightValue)) * 100;
+  const rightPercent = (rightValue / (leftValue + rightValue)) * 100;
+  const isLeftWinning = leftPercent >= rightPercent;
+
+  return (
+    <StyledMatchingBarsContainer {...props}>
+      <StyledMatchingBar
+        isLeft
+        isWinning={isLeftWinning}
+        percent={leftPercent}
+        style={{zIndex: isLeftWinning ? 2 : 0}}>
+        {/* NOTE: @emotion/native z-index 미동작 */}
+        <StyledMatchingBarProfile
+          isLeft
+          isWinning={isLeftWinning}
+          style={{zIndex: isLeftWinning ? 2 : 0}}>
+          <Text
+            text={leftName[0]}
+            color="gray-0"
+            type="body2"
+            fontWeight="700"
+          />
+        </StyledMatchingBarProfile>
+      </StyledMatchingBar>
+
+      <StyledMatchingBar
+        isLeft={false}
+        isWinning={!isLeftWinning}
+        percent={rightPercent}>
+        <StyledMatchingBarProfile
+          isLeft={false}
+          isWinning={!isLeftWinning}
+          style={{zIndex: isLeftWinning ? 0 : 2}}>
+          <Text
+            text={rightName[0]}
+            color="gray-0"
+            type="body2"
+            fontWeight="700"
+          />
+        </StyledMatchingBarProfile>
+      </StyledMatchingBar>
+    </StyledMatchingBarsContainer>
+  );
+};
+
+const StyledMatchingBarsContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  justify-content: space-between;
+`;
+
+const StyledMatchingBar = styled.View<{
+  isLeft: boolean;
+  isWinning: boolean;
+  percent: number;
+}>`
+  display: flex;
+  flex-direction: row;
+  background-color: ${({theme, isLeft, isWinning}) =>
+    !isWinning
+      ? theme.palette['gray-400']
+      : isLeft
+      ? theme.palette['main-400']
+      : theme.palette['sub-400']};
+  height: 8px;
+  border-radius: 4px;
+  width: ${({percent}) => `${percent}%`};
+  position: relative;
+`;
+
+const StyledMatchingBarProfile = styled.View<{
+  isLeft: boolean;
+  isWinning: boolean;
+}>`
+  width: 30px;
+  height: 30px;
+  border-radius: 15px;
+  position: absolute;
+  top: -10px;
+  left: ${({isLeft}) => (isLeft ? 'auto' : '-4px')};
+  right: ${({isLeft}) => (isLeft ? '-4px' : 'auto')};
+  background-color: ${({theme, isLeft, isWinning}) =>
+    !isWinning
+      ? theme.palette['gray-400']
+      : isLeft
+      ? theme.palette['main-400']
+      : theme.palette['sub-400']};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
@@ -8,6 +8,7 @@ import {
   MatchingPreviewSectionCardListItem,
 } from './MatchingPreviewSectionCard';
 import {NoMatching} from './NoMatching';
+import {ProfileName} from './ProfileName';
 import {Text} from '../../../../components/Text';
 import {useGetUserFieldHomeBattle} from '../../hooks/userField';
 import {type THomeBattleField} from '../../types';
@@ -94,18 +95,13 @@ export const MatchingPreviewDuelBattleSection = (): React.JSX.Element => {
             <StyledBattleListContainer>
               <MatchingPreviewSectionCardListItem label="기록횟수">
                 <DescriptionContainer>
-                  <StyledBattleProfile
+                  <ProfileName
                     isHome={
                       duelBattleInfos.totalRecordCount.winningUserName ===
                       userFieldBattle.home.name
-                    }>
-                    <Text
-                      text={duelBattleInfos.totalRecordCount.winningUserName[0]}
-                      color="gray-0"
-                      type="body2"
-                      fontWeight="700"
-                    />
-                  </StyledBattleProfile>
+                    }
+                    name={duelBattleInfos.totalRecordCount.winningUserName[0]}
+                  />
                   <Text
                     text={`님이 ${duelBattleInfos.totalRecordCount.gap}회 더 앞서있어요!`}
                     type="body3"
@@ -116,20 +112,13 @@ export const MatchingPreviewDuelBattleSection = (): React.JSX.Element => {
 
               <MatchingPreviewSectionCardListItem label="활동링 달성">
                 <DescriptionContainer>
-                  <StyledBattleProfile
+                  <ProfileName
                     isHome={
                       duelBattleInfos.goalAchievedCount.winningUserName ===
                       userFieldBattle.home.name
-                    }>
-                    <Text
-                      text={
-                        duelBattleInfos.goalAchievedCount.winningUserName[0]
-                      }
-                      color="gray-0"
-                      type="body2"
-                      fontWeight="700"
-                    />
-                  </StyledBattleProfile>
+                    }
+                    name={duelBattleInfos.goalAchievedCount.winningUserName[0]}
+                  />
                   <Text
                     // TODO(@minimalKim): 수치 %인지 확인
                     text={`님이 ${duelBattleInfos.goalAchievedCount.gap}% 더 앞서있어요!`}
@@ -141,21 +130,15 @@ export const MatchingPreviewDuelBattleSection = (): React.JSX.Element => {
 
               <MatchingPreviewSectionCardListItem label="운동시간">
                 <DescriptionContainer>
-                  <StyledBattleProfile
+                  <ProfileName
                     isHome={
                       duelBattleInfos.totalExerciseTimeMinute
                         .winningUserName === userFieldBattle.home.name
-                    }>
-                    <Text
-                      text={
-                        duelBattleInfos.totalExerciseTimeMinute
-                          .winningUserName[0]
-                      }
-                      color="gray-0"
-                      type="body2"
-                      fontWeight="700"
-                    />
-                  </StyledBattleProfile>
+                    }
+                    name={
+                      duelBattleInfos.totalExerciseTimeMinute.winningUserName[0]
+                    }
+                  />
                   <Text
                     text={`님이 ${duelBattleInfos.totalExerciseTimeMinute.gap}분 더 앞서있어요!`}
                     type="body3"
@@ -166,20 +149,13 @@ export const MatchingPreviewDuelBattleSection = (): React.JSX.Element => {
 
               <MatchingPreviewSectionCardListItem label="소모칼로리">
                 <DescriptionContainer>
-                  <StyledBattleProfile
+                  <ProfileName
                     isHome={
                       duelBattleInfos.totalBurnedCalorie.winningUserName ===
                       userFieldBattle.home.name
-                    }>
-                    <Text
-                      text={
-                        duelBattleInfos.totalBurnedCalorie.winningUserName[0]
-                      }
-                      color="gray-0"
-                      type="body2"
-                      fontWeight="700"
-                    />
-                  </StyledBattleProfile>
+                    }
+                    name={duelBattleInfos.totalBurnedCalorie.winningUserName[0]}
+                  />
                   <Text
                     text={`님이 ${duelBattleInfos.totalBurnedCalorie.gap}회 더 앞서있어요!`}
                     type="body3"
@@ -214,17 +190,7 @@ const DescriptionContainer = styled.View`
   flex-direction: row;
   align-items: center;
   gap: 4px;
-`;
-
-const StyledBattleProfile = styled.View<{
-  isHome: boolean;
-}>`
-  width: 30px;
-  height: 30px;
-  border-radius: 15px;
-  background-color: ${({theme, isHome}) =>
-    isHome ? theme.palette['main-400'] : theme.palette['sub-400']};
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  width: 100%;
+  min-width: 180px;
+  max-width: 65%;
 `;

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
@@ -103,21 +103,22 @@ export const MatchingPreviewDuelBattleSection = (): React.JSX.Element => {
               </MatchingPreviewSectionCardListItem>
               <MatchingPreviewSectionCardListItem label="활동링 달성">
                 <Text
-                  text={`${duelBattleInfos.totalRecordCount.winningUserName}님이 ${duelBattleInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  // TODO(@minimalKim): 수치 %인지 확인
+                  text={`${duelBattleInfos.goalAchievedCount.winningUserName}님이 ${duelBattleInfos?.goalAchievedCount.gap}% 더 앞서있어요!`}
                   type="body3"
                   color="gray-600"
                 />
               </MatchingPreviewSectionCardListItem>
               <MatchingPreviewSectionCardListItem label="운동시간">
                 <Text
-                  text={`${duelBattleInfos.totalRecordCount.winningUserName}님이 ${duelBattleInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  text={`${duelBattleInfos.totalExerciseTimeMinute.winningUserName}님이 ${duelBattleInfos?.totalExerciseTimeMinute.gap}분 더 앞서있어요!`}
                   type="body3"
                   color="gray-600"
                 />
               </MatchingPreviewSectionCardListItem>
               <MatchingPreviewSectionCardListItem label="소모칼로리">
                 <Text
-                  text={`${duelBattleInfos.totalRecordCount.winningUserName}님이 ${duelBattleInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  text={`${duelBattleInfos.totalBurnedCalorie.winningUserName}님이 ${duelBattleInfos?.totalBurnedCalorie.gap}회 더 앞서있어요!`}
                   type="body3"
                   color="gray-600"
                 />

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
@@ -13,24 +13,26 @@ import {useGetUserFieldHomeBattle} from '../../hooks/userField';
 import {type IUserFieldHomeBattle} from '../../types';
 
 type THomeBattleField = Exclude<keyof IUserFieldHomeBattle, 'name'>;
-interface IHomeBattleListInfo {
-  gap: number;
-  winningUserName: string;
-}
 
-type THomeBattleListInfos = Record<THomeBattleField, IHomeBattleListInfo>;
+type THomeBattleFieldInfos = Record<
+  THomeBattleField,
+  {
+    gap: number;
+    winningUserName: string;
+  }
+>;
 
-export const MatchingPreviewDuelSection = (): React.JSX.Element => {
+export const MatchingPreviewDuelBattleSection = (): React.JSX.Element => {
   const {data: userFieldBattle} = useGetUserFieldHomeBattle({
     battleType: 'DUEL',
   });
 
-  const duelFieldInfos: THomeBattleListInfos | null = useMemo(() => {
+  const duelBattleInfos: THomeBattleFieldInfos | null = useMemo(() => {
     if (userFieldBattle == null) {
       return null;
     }
 
-    const result: THomeBattleListInfos = {
+    const result: THomeBattleFieldInfos = {
       goalAchievedCount: {
         gap: 0,
         winningUserName: '',
@@ -76,7 +78,7 @@ export const MatchingPreviewDuelSection = (): React.JSX.Element => {
 
   return (
     <View>
-      {userFieldBattle != null && duelFieldInfos != null ? (
+      {userFieldBattle != null && duelBattleInfos != null ? (
         <MatchingPreviewSectionCard
           title={() => (
             <StyledTitleContainer>
@@ -94,28 +96,28 @@ export const MatchingPreviewDuelSection = (): React.JSX.Element => {
             <StyledBattleListContainer>
               <MatchingPreviewSectionCardListItem label="기록횟수">
                 <Text
-                  text={`${duelFieldInfos.totalRecordCount.winningUserName}님이 ${duelFieldInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  text={`${duelBattleInfos.totalRecordCount.winningUserName}님이 ${duelBattleInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
                   type="body3"
                   color="gray-600"
                 />
               </MatchingPreviewSectionCardListItem>
               <MatchingPreviewSectionCardListItem label="활동링 달성">
                 <Text
-                  text={`${duelFieldInfos.totalRecordCount.winningUserName}님이 ${duelFieldInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  text={`${duelBattleInfos.totalRecordCount.winningUserName}님이 ${duelBattleInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
                   type="body3"
                   color="gray-600"
                 />
               </MatchingPreviewSectionCardListItem>
               <MatchingPreviewSectionCardListItem label="운동시간">
                 <Text
-                  text={`${duelFieldInfos.totalRecordCount.winningUserName}님이 ${duelFieldInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  text={`${duelBattleInfos.totalRecordCount.winningUserName}님이 ${duelBattleInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
                   type="body3"
                   color="gray-600"
                 />
               </MatchingPreviewSectionCardListItem>
               <MatchingPreviewSectionCardListItem label="소모칼로리">
                 <Text
-                  text={`${duelFieldInfos.totalRecordCount.winningUserName}님이 ${duelFieldInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  text={`${duelBattleInfos.totalRecordCount.winningUserName}님이 ${duelBattleInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
                   type="body3"
                   color="gray-600"
                 />

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
@@ -10,11 +10,9 @@ import {
 import {NoMatching} from './NoMatching';
 import {Text} from '../../../../components/Text';
 import {useGetUserFieldHomeBattle} from '../../hooks/userField';
-import {type IUserFieldHomeBattle} from '../../types';
+import {type THomeBattleField} from '../../types';
 
-type THomeBattleField = Exclude<keyof IUserFieldHomeBattle, 'name'>;
-
-type THomeBattleFieldInfos = Record<
+type THomeDuelBattleFieldInfos = Record<
   THomeBattleField,
   {
     gap: number;
@@ -27,12 +25,12 @@ export const MatchingPreviewDuelBattleSection = (): React.JSX.Element => {
     battleType: 'DUEL',
   });
 
-  const duelBattleInfos: THomeBattleFieldInfos | null = useMemo(() => {
+  const duelBattleInfos: THomeDuelBattleFieldInfos | null = useMemo(() => {
     if (userFieldBattle == null) {
       return null;
     }
 
-    const result: THomeBattleFieldInfos = {
+    const result: THomeDuelBattleFieldInfos = {
       goalAchievedCount: {
         gap: 0,
         winningUserName: '',
@@ -77,7 +75,7 @@ export const MatchingPreviewDuelBattleSection = (): React.JSX.Element => {
   }, [userFieldBattle]);
 
   return (
-    <View>
+    <>
       {userFieldBattle != null && duelBattleInfos != null ? (
         <MatchingPreviewSectionCard
           title={() => (
@@ -129,7 +127,7 @@ export const MatchingPreviewDuelBattleSection = (): React.JSX.Element => {
       ) : (
         <NoMatching />
       )}
-    </View>
+    </>
   );
 };
 
@@ -140,7 +138,7 @@ const StyledTitleContainer = styled.View`
 
 const StyledBattleListContainer = styled.View`
   display: flex;
-  gap: 20px;
+  gap: 26px;
   margin-top: 16px;
   padding-right: 16px;
 `;

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
@@ -93,33 +93,99 @@ export const MatchingPreviewDuelBattleSection = (): React.JSX.Element => {
             />
             <StyledBattleListContainer>
               <MatchingPreviewSectionCardListItem label="기록횟수">
-                <Text
-                  text={`${duelBattleInfos.totalRecordCount.winningUserName}님이 ${duelBattleInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
-                  type="body3"
-                  color="gray-600"
-                />
+                <DescriptionContainer>
+                  <StyledBattleProfile
+                    isHome={
+                      duelBattleInfos.totalRecordCount.winningUserName ===
+                      userFieldBattle.home.name
+                    }>
+                    <Text
+                      text={duelBattleInfos.totalRecordCount.winningUserName[0]}
+                      color="gray-0"
+                      type="body2"
+                      fontWeight="700"
+                    />
+                  </StyledBattleProfile>
+                  <Text
+                    text={`님이 ${duelBattleInfos.totalRecordCount.gap}회 더 앞서있어요!`}
+                    type="body3"
+                    color="gray-600"
+                  />
+                </DescriptionContainer>
               </MatchingPreviewSectionCardListItem>
+
               <MatchingPreviewSectionCardListItem label="활동링 달성">
-                <Text
-                  // TODO(@minimalKim): 수치 %인지 확인
-                  text={`${duelBattleInfos.goalAchievedCount.winningUserName}님이 ${duelBattleInfos?.goalAchievedCount.gap}% 더 앞서있어요!`}
-                  type="body3"
-                  color="gray-600"
-                />
+                <DescriptionContainer>
+                  <StyledBattleProfile
+                    isHome={
+                      duelBattleInfos.goalAchievedCount.winningUserName ===
+                      userFieldBattle.home.name
+                    }>
+                    <Text
+                      text={
+                        duelBattleInfos.goalAchievedCount.winningUserName[0]
+                      }
+                      color="gray-0"
+                      type="body2"
+                      fontWeight="700"
+                    />
+                  </StyledBattleProfile>
+                  <Text
+                    // TODO(@minimalKim): 수치 %인지 확인
+                    text={`님이 ${duelBattleInfos.goalAchievedCount.gap}% 더 앞서있어요!`}
+                    type="body3"
+                    color="gray-600"
+                  />
+                </DescriptionContainer>
               </MatchingPreviewSectionCardListItem>
+
               <MatchingPreviewSectionCardListItem label="운동시간">
-                <Text
-                  text={`${duelBattleInfos.totalExerciseTimeMinute.winningUserName}님이 ${duelBattleInfos?.totalExerciseTimeMinute.gap}분 더 앞서있어요!`}
-                  type="body3"
-                  color="gray-600"
-                />
+                <DescriptionContainer>
+                  <StyledBattleProfile
+                    isHome={
+                      duelBattleInfos.totalExerciseTimeMinute
+                        .winningUserName === userFieldBattle.home.name
+                    }>
+                    <Text
+                      text={
+                        duelBattleInfos.totalExerciseTimeMinute
+                          .winningUserName[0]
+                      }
+                      color="gray-0"
+                      type="body2"
+                      fontWeight="700"
+                    />
+                  </StyledBattleProfile>
+                  <Text
+                    text={`님이 ${duelBattleInfos.totalExerciseTimeMinute.gap}분 더 앞서있어요!`}
+                    type="body3"
+                    color="gray-600"
+                  />
+                </DescriptionContainer>
               </MatchingPreviewSectionCardListItem>
+
               <MatchingPreviewSectionCardListItem label="소모칼로리">
-                <Text
-                  text={`${duelBattleInfos.totalBurnedCalorie.winningUserName}님이 ${duelBattleInfos?.totalBurnedCalorie.gap}회 더 앞서있어요!`}
-                  type="body3"
-                  color="gray-600"
-                />
+                <DescriptionContainer>
+                  <StyledBattleProfile
+                    isHome={
+                      duelBattleInfos.totalBurnedCalorie.winningUserName ===
+                      userFieldBattle.home.name
+                    }>
+                    <Text
+                      text={
+                        duelBattleInfos.totalBurnedCalorie.winningUserName[0]
+                      }
+                      color="gray-0"
+                      type="body2"
+                      fontWeight="700"
+                    />
+                  </StyledBattleProfile>
+                  <Text
+                    text={`님이 ${duelBattleInfos.totalBurnedCalorie.gap}회 더 앞서있어요!`}
+                    type="body3"
+                    color="gray-600"
+                  />
+                </DescriptionContainer>
               </MatchingPreviewSectionCardListItem>
             </StyledBattleListContainer>
           </View>
@@ -138,7 +204,27 @@ const StyledTitleContainer = styled.View`
 
 const StyledBattleListContainer = styled.View`
   display: flex;
-  gap: 26px;
+  gap: 20px;
   margin-top: 16px;
   padding-right: 16px;
+`;
+
+const DescriptionContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4;
+`;
+
+const StyledBattleProfile = styled.View<{
+  isHome: boolean;
+}>`
+  width: 30px;
+  height: 30px;
+  border-radius: 15px;
+  background-color: ${({theme, isHome}) =>
+    isHome ? theme.palette['main-400'] : theme.palette['sub-400']};
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelBattleSection.tsx
@@ -213,7 +213,7 @@ const DescriptionContainer = styled.View`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 4;
+  gap: 4px;
 `;
 
 const StyledBattleProfile = styled.View<{

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewDuelSection.tsx
@@ -1,0 +1,143 @@
+import React, {useMemo} from 'react';
+
+import styled from '@emotion/native';
+import {View} from 'react-native';
+
+import {
+  MatchingPreviewSectionCard,
+  MatchingPreviewSectionCardListItem,
+} from './MatchingPreviewSectionCard';
+import {NoMatching} from './NoMatching';
+import {Text} from '../../../../components/Text';
+import {useGetUserFieldHomeBattle} from '../../hooks/userField';
+import {type IUserFieldHomeBattle} from '../../types';
+
+type THomeBattleField = Exclude<keyof IUserFieldHomeBattle, 'name'>;
+interface IHomeBattleListInfo {
+  gap: number;
+  winningUserName: string;
+}
+
+type THomeBattleListInfos = Record<THomeBattleField, IHomeBattleListInfo>;
+
+export const MatchingPreviewDuelSection = (): React.JSX.Element => {
+  const {data: userFieldBattle} = useGetUserFieldHomeBattle({
+    battleType: 'DUEL',
+  });
+
+  const duelFieldInfos: THomeBattleListInfos | null = useMemo(() => {
+    if (userFieldBattle == null) {
+      return null;
+    }
+
+    const result: THomeBattleListInfos = {
+      goalAchievedCount: {
+        gap: 0,
+        winningUserName: '',
+      },
+      totalBurnedCalorie: {
+        gap: 0,
+        winningUserName: '',
+      },
+      totalExerciseTimeMinute: {
+        gap: 0,
+        winningUserName: '',
+      },
+      totalRecordCount: {
+        gap: 0,
+        winningUserName: '',
+      },
+    };
+
+    const fields = Object.keys(userFieldBattle.home).filter(
+      key => key !== 'name',
+    ) as THomeBattleField[];
+
+    fields.forEach(field => {
+      const gap = Math.abs(
+        userFieldBattle.home[field] - userFieldBattle.away[field],
+      );
+
+      const winningUserName =
+        // TODO(@minimalKim): 값 동일한 경우 UI 명세 요청
+        userFieldBattle.home[field] >= userFieldBattle.away[field]
+          ? userFieldBattle.home.name
+          : userFieldBattle.away.name;
+
+      result[field] = {
+        ...result[field],
+        gap,
+        winningUserName,
+      };
+    });
+
+    return result;
+  }, [userFieldBattle]);
+
+  return (
+    <View>
+      {userFieldBattle != null && duelFieldInfos != null ? (
+        <MatchingPreviewSectionCard
+          title={() => (
+            <StyledTitleContainer>
+              <Text text={`${userFieldBattle?.away?.name}`} fontWeight="600" />
+              <Text text="님과 대결 중" />
+            </StyledTitleContainer>
+          )}
+          onPress={() => {}}>
+          <View>
+            <Text
+              type="caption"
+              color="gray-600"
+              text={`완료까지${userFieldBattle.daysLeft}일`}
+            />
+            <StyledBattleListContainer>
+              <MatchingPreviewSectionCardListItem label="기록횟수">
+                <Text
+                  text={`${duelFieldInfos.totalRecordCount.winningUserName}님이 ${duelFieldInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  type="body3"
+                  color="gray-600"
+                />
+              </MatchingPreviewSectionCardListItem>
+              <MatchingPreviewSectionCardListItem label="활동링 달성">
+                <Text
+                  text={`${duelFieldInfos.totalRecordCount.winningUserName}님이 ${duelFieldInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  type="body3"
+                  color="gray-600"
+                />
+              </MatchingPreviewSectionCardListItem>
+              <MatchingPreviewSectionCardListItem label="운동시간">
+                <Text
+                  text={`${duelFieldInfos.totalRecordCount.winningUserName}님이 ${duelFieldInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  type="body3"
+                  color="gray-600"
+                />
+              </MatchingPreviewSectionCardListItem>
+              <MatchingPreviewSectionCardListItem label="소모칼로리">
+                <Text
+                  text={`${duelFieldInfos.totalRecordCount.winningUserName}님이 ${duelFieldInfos?.totalRecordCount.gap}회 더 앞서있어요!`}
+                  type="body3"
+                  color="gray-600"
+                />
+              </MatchingPreviewSectionCardListItem>
+            </StyledBattleListContainer>
+          </View>
+        </MatchingPreviewSectionCard>
+      ) : (
+        <NoMatching />
+      )}
+    </View>
+  );
+};
+
+const StyledTitleContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+`;
+
+const StyledBattleListContainer = styled.View`
+  display: flex;
+  gap: 20px;
+  margin-top: 16px;
+  padding-right: 16px;
+`;

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewSectionCard/MatchingPreviewSectionCard.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewSectionCard/MatchingPreviewSectionCard.tsx
@@ -2,6 +2,7 @@ import React, {type PropsWithChildren} from 'react';
 
 import styled from '@emotion/native';
 
+import {theme} from '../../../../../assets/styles/theme';
 import {arrowRightXmlData} from '../../../../../assets/svg';
 import {Icon} from '../../../../../components/Icon';
 
@@ -20,7 +21,12 @@ export const MatchingPreviewSectionCard = ({
       <StyledMatchingPreviewSectionCard>
         <StyledTitleContainer onPress={onPress}>
           <StyledTitleTextContainer>{title()}</StyledTitleTextContainer>
-          <Icon svgXml={arrowRightXmlData} width={40} height={40} />
+          <Icon
+            svgXml={arrowRightXmlData}
+            width={40}
+            height={40}
+            color={theme.palette.black}
+          />
         </StyledTitleContainer>
         {children}
       </StyledMatchingPreviewSectionCard>

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewSectionCard/MatchingPreviewSectionCard.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewSectionCard/MatchingPreviewSectionCard.tsx
@@ -1,0 +1,54 @@
+import React, {type PropsWithChildren} from 'react';
+
+import styled from '@emotion/native';
+
+import {arrowRightXmlData} from '../../../../../assets/svg';
+import {Icon} from '../../../../../components/Icon';
+
+interface IMatchingPreviewSectionInnerCardProps extends PropsWithChildren {
+  title: () => React.JSX.Element;
+  onPress: () => void;
+}
+
+export const MatchingPreviewSectionCard = ({
+  title,
+  onPress,
+  children,
+}: IMatchingPreviewSectionInnerCardProps): React.JSX.Element => {
+  return (
+    <StyledMatchingPreviewSectionCardWrapper>
+      <StyledMatchingPreviewSectionCard>
+        <StyledTitleContainer onPress={onPress}>
+          <StyledTitleTextContainer>{title()}</StyledTitleTextContainer>
+          <Icon svgXml={arrowRightXmlData} width={40} height={40} />
+        </StyledTitleContainer>
+        {children}
+      </StyledMatchingPreviewSectionCard>
+    </StyledMatchingPreviewSectionCardWrapper>
+  );
+};
+
+const StyledMatchingPreviewSectionCardWrapper = styled.View`
+  background-color: ${({theme}) => theme.palette['gray-0']};
+  width: 100%;
+`;
+
+const StyledMatchingPreviewSectionCard = styled.View`
+  background-color: ${({theme}) => theme.palette['gray-50']};
+  border-radius: ${({theme}) => theme.borderRadius.md};
+  padding: 20px;
+  width: 100%;
+`;
+
+const StyledTitleContainer = styled.TouchableOpacity`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const StyledTitleTextContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewSectionCard/MatchingPreviewSectionCard.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewSectionCard/MatchingPreviewSectionCard.tsx
@@ -37,6 +37,7 @@ const StyledMatchingPreviewSectionCard = styled.View`
   background-color: ${({theme}) => theme.palette['gray-50']};
   border-radius: ${({theme}) => theme.borderRadius.md};
   padding: 20px;
+  padding-bottom: 26px;
   width: 100%;
 `;
 

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewSectionCard/MatchingPreviewSectionCardListItem.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewSectionCard/MatchingPreviewSectionCardListItem.tsx
@@ -1,0 +1,28 @@
+import React, {type PropsWithChildren} from 'react';
+
+import styled from '@emotion/native';
+
+import {Text} from '../../../../../components/Text';
+
+interface IMatchingPreviewSectionCardListItemProps extends PropsWithChildren {
+  label: string;
+}
+
+export const MatchingPreviewSectionCardListItem = ({
+  label,
+  children,
+}: IMatchingPreviewSectionCardListItemProps): React.JSX.Element => {
+  return (
+    <StyledBattleListItemContainer>
+      <Text text={label} type="body2" fontWeight="700" color="gray-600" />
+      {children}
+    </StyledBattleListItemContainer>
+  );
+};
+
+const StyledBattleListItemContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewSectionCard/index.ts
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewSectionCard/index.ts
@@ -1,0 +1,2 @@
+export * from './MatchingPreviewSectionCard';
+export * from './MatchingPreviewSectionCardListItem';

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewTeamBattleSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewTeamBattleSection.tsx
@@ -12,7 +12,7 @@ import {NoMatching} from './NoMatching';
 import {Text} from '../../../../components/Text';
 import {useGetUserFieldHomeBattle} from '../../hooks/userField';
 
-export const MatchingPreviewTeamSection = (): React.JSX.Element => {
+export const MatchingPreviewTeamBattleSection = (): React.JSX.Element => {
   const {data: userFieldBattle} = useGetUserFieldHomeBattle({
     battleType: 'TEAM_BATTLE',
   });

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewTeamBattleSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewTeamBattleSection.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+import {View} from 'react-native';
+
+import {MatchingBar} from './MatchingBar';
+import {
+  MatchingPreviewSectionCard,
+  MatchingPreviewSectionCardListItem,
+} from './MatchingPreviewSectionCard';
+import {NoMatching} from './NoMatching';
+import {Text} from '../../../../components/Text';
+import {useGetUserFieldHomeBattle} from '../../hooks/userField';
+
+export const MatchingPreviewTeamSection = (): React.JSX.Element => {
+  const {data: userFieldBattle} = useGetUserFieldHomeBattle({
+    battleType: 'TEAM_BATTLE',
+  });
+
+  return (
+    <>
+      {userFieldBattle != null ? (
+        <MatchingPreviewSectionCard
+          title={() => (
+            <StyledTitleContainer>
+              <Text
+                text={`${userFieldBattle.home.name} VS ${userFieldBattle.away.name}`}
+                fontWeight="600"
+              />
+            </StyledTitleContainer>
+          )}
+          onPress={() => {}}>
+          <View>
+            <Text
+              type="caption"
+              color="gray-600"
+              text={`완료까지${userFieldBattle.daysLeft}일`}
+            />
+            <StyledMatchingBarContainer>
+              <MatchingPreviewSectionCardListItem label="기록횟수">
+                <MatchingBar
+                  leftValue={userFieldBattle.home.totalRecordCount}
+                  rightValue={userFieldBattle.away.totalRecordCount}
+                  leftName={userFieldBattle.home.name}
+                  rightName={userFieldBattle.away.name}
+                  style={{width: '70%'}}
+                />
+              </MatchingPreviewSectionCardListItem>
+              <MatchingPreviewSectionCardListItem label="활동링 달성">
+                <MatchingBar
+                  leftValue={userFieldBattle.home.goalAchievedCount}
+                  rightValue={userFieldBattle.away.goalAchievedCount}
+                  leftName={userFieldBattle.home.name}
+                  rightName={userFieldBattle.away.name}
+                  style={{width: '70%'}}
+                />
+              </MatchingPreviewSectionCardListItem>
+              <MatchingPreviewSectionCardListItem label="운동시간">
+                <MatchingBar
+                  leftValue={userFieldBattle.home.totalExerciseTimeMinute}
+                  rightValue={userFieldBattle.away.totalExerciseTimeMinute}
+                  leftName={userFieldBattle.home.name}
+                  rightName={userFieldBattle.away.name}
+                  style={{width: '70%'}}
+                />
+              </MatchingPreviewSectionCardListItem>
+              <MatchingPreviewSectionCardListItem label="소모칼로리">
+                <MatchingBar
+                  leftValue={userFieldBattle.home.totalBurnedCalorie}
+                  rightValue={userFieldBattle.away.totalBurnedCalorie}
+                  leftName={userFieldBattle.home.name}
+                  rightName={userFieldBattle.away.name}
+                  style={{width: '70%'}}
+                />
+              </MatchingPreviewSectionCardListItem>
+            </StyledMatchingBarContainer>
+          </View>
+        </MatchingPreviewSectionCard>
+      ) : (
+        <NoMatching />
+      )}
+    </>
+  );
+};
+
+const StyledTitleContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+`;
+
+const StyledMatchingBarContainer = styled.View`
+  display: flex;
+  display: flex;
+  gap: 30px;
+  margin-top: 26px;
+  margin-bottom: 6px;
+`;

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewTeamSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewTeamSection.tsx
@@ -46,7 +46,7 @@ export const MatchingPreviewTeamSection = (): React.JSX.Element => {
                     name={userFieldHomeTeam.recordCount.name[0]}
                   />
                   <Text
-                    text={`님이 ${userFieldHomeTeam.recordCount.value}로 1등!`}
+                    text={`님이 ${userFieldHomeTeam.recordCount.value}회로 1등!`}
                     type="body3"
                     color="gray-600"
                   />
@@ -64,7 +64,7 @@ export const MatchingPreviewTeamSection = (): React.JSX.Element => {
                   />
                   <Text
                     // TODO(@minimalKim): 수치 %인지 확인
-                    text={`님이 ${userFieldHomeTeam.goalAchievedCount.value}로 1등!`}
+                    text={`님이 ${userFieldHomeTeam.goalAchievedCount.value}%로 1등!`}
                     type="body3"
                     color="gray-600"
                   />

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewTeamSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewTeamSection.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+import {View} from 'react-native';
+
+import {
+  MatchingPreviewSectionCard,
+  MatchingPreviewSectionCardListItem,
+} from './MatchingPreviewSectionCard';
+import {NoMatching} from './NoMatching';
+import {ProfileName} from './ProfileName';
+import {Text} from '../../../../components/Text';
+import {useGetMyProfileDetail} from '../../../my/hooks/profile';
+import {useGetUserFieldHomeTeam} from '../../hooks/userField';
+
+export const MatchingPreviewTeamSection = (): React.JSX.Element => {
+  const {data: userFieldHomeTeam} = useGetUserFieldHomeTeam();
+  const {data: myProfileDetail} = useGetMyProfileDetail();
+  console.log('userFieldHomeTeam', userFieldHomeTeam);
+
+  return (
+    <>
+      {userFieldHomeTeam != null ? (
+        <MatchingPreviewSectionCard
+          title={() => (
+            <StyledTitleContainer>
+              <Text text={`${userFieldHomeTeam.teamName}팀`} fontWeight="600" />
+              <Text text="에서 달리는 중" />
+            </StyledTitleContainer>
+          )}
+          onPress={() => {}}>
+          <View>
+            <Text
+              type="caption"
+              color="gray-600"
+              text={`완료까지${userFieldHomeTeam.daysLeft}일`}
+            />
+            <StyledBattleListContainer>
+              <MatchingPreviewSectionCardListItem label="기록횟수">
+                <DescriptionContainer>
+                  <ProfileName
+                    isHome={
+                      myProfileDetail?.name ===
+                      userFieldHomeTeam.recordCount.name
+                    }
+                    name={userFieldHomeTeam.recordCount.name[0]}
+                  />
+                  <Text
+                    text={`님이 ${userFieldHomeTeam.recordCount.value}로 1등!`}
+                    type="body3"
+                    color="gray-600"
+                  />
+                </DescriptionContainer>
+              </MatchingPreviewSectionCardListItem>
+
+              <MatchingPreviewSectionCardListItem label="활동링 달성">
+                <DescriptionContainer>
+                  <ProfileName
+                    isHome={
+                      myProfileDetail?.name ===
+                      userFieldHomeTeam.goalAchievedCount.name
+                    }
+                    name={userFieldHomeTeam.goalAchievedCount.name[0]}
+                  />
+                  <Text
+                    // TODO(@minimalKim): 수치 %인지 확인
+                    text={`님이 ${userFieldHomeTeam.goalAchievedCount.value}로 1등!`}
+                    type="body3"
+                    color="gray-600"
+                  />
+                </DescriptionContainer>
+              </MatchingPreviewSectionCardListItem>
+
+              <MatchingPreviewSectionCardListItem label="운동시간">
+                <DescriptionContainer>
+                  <ProfileName
+                    isHome={
+                      myProfileDetail?.name ===
+                      userFieldHomeTeam.exerciseTimeMinute.name
+                    }
+                    name={userFieldHomeTeam.goalAchievedCount.name[0]}
+                  />
+                  <Text
+                    text={`님이 ${userFieldHomeTeam.exerciseTimeMinute.value}분으로 1등!`}
+                    type="body3"
+                    color="gray-600"
+                  />
+                </DescriptionContainer>
+              </MatchingPreviewSectionCardListItem>
+
+              <MatchingPreviewSectionCardListItem label="소모칼로리">
+                <DescriptionContainer>
+                  <ProfileName
+                    isHome={
+                      myProfileDetail?.name ===
+                      userFieldHomeTeam.burnedCalorie.name
+                    }
+                    name={userFieldHomeTeam.burnedCalorie.name[0]}
+                  />
+                  <Text
+                    text={`님이 ${userFieldHomeTeam.burnedCalorie.value}kcal로 1등!`}
+                    type="body3"
+                    color="gray-600"
+                  />
+                </DescriptionContainer>
+              </MatchingPreviewSectionCardListItem>
+            </StyledBattleListContainer>
+          </View>
+        </MatchingPreviewSectionCard>
+      ) : (
+        <NoMatching />
+      )}
+    </>
+  );
+};
+
+const StyledTitleContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+`;
+
+const StyledBattleListContainer = styled.View`
+  display: flex;
+  gap: 20px;
+  margin-top: 16px;
+  padding-right: 16px;
+`;
+
+const DescriptionContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 180px;
+  max-width: 65%;
+`;

--- a/src/features/home/components/MatchPreviewSection/NoMatching.tsx
+++ b/src/features/home/components/MatchPreviewSection/NoMatching.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+
+import {Text} from '../../../../components/Text';
+
+export const NoMatching = (): React.JSX.Element => {
+  return (
+    <StyledNoMatchingContainer>
+      <Text
+        text={`진행 중인 \n매칭이 없어요`}
+        textAlign="center"
+        color="gray-600"
+        type="body3"
+      />
+      <StyledMatchingButton>
+        <Text
+          text="매칭 상대 찾아보기"
+          type="body3"
+          fontWeight="600"
+          color="gray-600"
+        />
+      </StyledMatchingButton>
+    </StyledNoMatchingContainer>
+  );
+};
+
+const StyledNoMatchingContainer = styled.View`
+  height: 400px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+`;
+
+const StyledMatchingButton = styled.TouchableOpacity`
+  border-radius: 16px;
+  background-color: ${({theme}) => theme.palette['gray-100']};
+  padding: 16px 26px;
+`;

--- a/src/features/home/components/MatchPreviewSection/NoMatching.tsx
+++ b/src/features/home/components/MatchPreviewSection/NoMatching.tsx
@@ -26,7 +26,7 @@ export const NoMatching = (): React.JSX.Element => {
 };
 
 const StyledNoMatchingContainer = styled.View`
-  height: 400px;
+  height: 300px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/features/home/components/MatchPreviewSection/ProfileName.tsx
+++ b/src/features/home/components/MatchPreviewSection/ProfileName.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+
+import {Text} from '../../../../components/Text';
+
+interface IProfileNameProps {
+  isHome: boolean;
+  name: string;
+}
+
+export const ProfileName = ({
+  isHome,
+  name,
+}: IProfileNameProps): React.JSX.Element => {
+  return (
+    <StyledProfileName isHome={isHome}>
+      <Text text={name[0]} color="gray-0" type="body2" fontWeight="700" />
+    </StyledProfileName>
+  );
+};
+
+const StyledProfileName = styled.View<{
+  isHome: boolean;
+}>`
+  width: 30px;
+  height: 30px;
+  border-radius: 15px;
+  background-color: ${({theme, isHome}) =>
+    isHome ? theme.palette['main-400'] : theme.palette['sub-400']};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/features/home/components/MatchPreviewSection/Tab/Tab.tsx
+++ b/src/features/home/components/MatchPreviewSection/Tab/Tab.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import {TouchableOpacity, Text} from 'react-native';
+
+import {theme} from '../../../../../assets/styles/theme';
+
+interface ITabProps {
+  title: string;
+  active: boolean;
+  onPress: () => void;
+}
+
+export const Tab = ({title, active, onPress}: ITabProps): React.JSX.Element => {
+  return (
+    <TouchableOpacity
+      style={{
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderBottomWidth: 2,
+        borderBottomColor: active
+          ? theme.palette['gray-500']
+          : theme.palette['gray-200'],
+      }}
+      onPress={onPress}>
+      <Text
+        style={{
+          color: active ? theme.palette['gray-700'] : theme.palette['gray-500'],
+        }}>
+        {title}
+      </Text>
+    </TouchableOpacity>
+  );
+};

--- a/src/features/home/components/MatchPreviewSection/Tab/TabContent.tsx
+++ b/src/features/home/components/MatchPreviewSection/Tab/TabContent.tsx
@@ -1,0 +1,40 @@
+import React, {type PropsWithChildren} from 'react';
+
+import styled from '@emotion/native';
+import {Animated} from 'react-native';
+
+interface ITabContent extends PropsWithChildren {
+  translateXTab: Animated.Value | number;
+  translateY?: Animated.Value | number;
+}
+
+export const TabContent = ({
+  translateXTab,
+  translateY,
+  children,
+}: ITabContent): React.JSX.Element => {
+  return (
+    <StyledAnimatedView
+      style={{
+        transform: [
+          {
+            translateX: translateXTab,
+          },
+          {
+            translateY: translateY ?? 0,
+          },
+        ],
+      }}>
+      <StyledView>{children}</StyledView>
+    </StyledAnimatedView>
+  );
+};
+
+const StyledAnimatedView = styled(Animated.View)(() => ({
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
+
+const StyledView = styled.View`
+  width: 100%;
+`;

--- a/src/features/home/components/MatchPreviewSection/Tab/index.ts
+++ b/src/features/home/components/MatchPreviewSection/Tab/index.ts
@@ -1,0 +1,2 @@
+export * from './Tab';
+export * from './TabContent';

--- a/src/features/home/components/MatchPreviewSection/index.ts
+++ b/src/features/home/components/MatchPreviewSection/index.ts
@@ -1,0 +1,1 @@
+export * from './MatchPreviewSection';

--- a/src/features/home/components/index.ts
+++ b/src/features/home/components/index.ts
@@ -1,3 +1,4 @@
 export * from './CurrentWorkoutSection';
 export * from './TodayCalorieSection';
 export * from './MainBanner';
+export * from './MatchPreviewSection';

--- a/src/features/home/hooks/userField/index.ts
+++ b/src/features/home/hooks/userField/index.ts
@@ -1,0 +1,2 @@
+export * from './useGetUserFieldHomeBattle';
+export * from './useGetUserFieldHomeTeam';

--- a/src/features/home/hooks/userField/keys.ts
+++ b/src/features/home/hooks/userField/keys.ts
@@ -1,0 +1,13 @@
+import {type TUserFieldBattleType} from '../../types/userField';
+
+export const KEYS = {
+  all: ['use-field'] as const,
+
+  home: () => [...KEYS.all, 'home'],
+  homeBattle: (battleType: TUserFieldBattleType) => [
+    ...KEYS.home(),
+    'battle',
+    battleType,
+  ],
+  homeTeam: () => [...KEYS.home(), 'team'],
+};

--- a/src/features/home/hooks/userField/useGetUserFieldHomeBattle.ts
+++ b/src/features/home/hooks/userField/useGetUserFieldHomeBattle.ts
@@ -1,0 +1,58 @@
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {axios} from '../../../../lib/axios';
+import {
+  type IUserFieldHomeBattle,
+  type TUserFieldBattleType,
+} from '../../types';
+
+interface IProps {
+  battleType: TUserFieldBattleType;
+}
+
+interface IResponse {
+  fieldId: number;
+  away: IUserFieldHomeBattle;
+  home: IUserFieldHomeBattle;
+  /** 완료까지 남은 일수 */
+  daysLeft: number;
+}
+
+const fetcher = async ({battleType}: IProps): Promise<IResponse> =>
+  await axios
+    .get(`/user-field/home/battle`, {
+      params: {
+        battleType,
+      },
+    })
+    .then(({data}) => data)
+    .then(() => ({
+      away: {
+        goalAchievedCount: 0,
+        name: 'test우저',
+        totalBurnedCalorie: 0,
+        totalExerciseTimeMinute: 0,
+        totalRecordCount: 0,
+      },
+      daysLeft: 0,
+      fieldId: 0,
+      home: {
+        goalAchievedCount: 0,
+        name: 'test우저2',
+        totalBurnedCalorie: 0,
+        totalExerciseTimeMinute: 0,
+        totalRecordCount: 0,
+      },
+    }));
+
+/**
+ * 홈화면 나의 배틀 현황 조회 (팀 제외)
+ */
+export const useGetUserFieldHomeBattle = ({
+  battleType,
+}: IProps): UseQueryResult<IResponse, Error> =>
+  useQuery({
+    queryKey: KEYS.homeBattle(battleType),
+    queryFn: async () => await fetcher({battleType}),
+  });

--- a/src/features/home/hooks/userField/useGetUserFieldHomeBattle.ts
+++ b/src/features/home/hooks/userField/useGetUserFieldHomeBattle.ts
@@ -20,31 +20,18 @@ interface IResponse {
 }
 
 const fetcher = async ({battleType}: IProps): Promise<IResponse> =>
+  // TODO(@minimalKim): 유저 썸네일 추가 요청 또는 디자인 명세 수정 요청
   await axios
     .get(`/user-field/home/battle`, {
       params: {
         battleType,
       },
     })
-    .then(({data}) => data)
-    .then(() => ({
-      away: {
-        goalAchievedCount: 0,
-        name: 'test우저',
-        totalBurnedCalorie: 0,
-        totalExerciseTimeMinute: 0,
-        totalRecordCount: 0,
-      },
-      daysLeft: 0,
-      fieldId: 0,
-      home: {
-        goalAchievedCount: 0,
-        name: 'test우저2',
-        totalBurnedCalorie: 0,
-        totalExerciseTimeMinute: 0,
-        totalRecordCount: 0,
-      },
-    }));
+    // TODO(@minimalKim): 진행 중인 배틀이 없을 경우 null이 아닌 빈 string 반환 됨 -> 백엔드 수정요청
+    .then(({data}) => {
+      if (data === '') return null;
+      return data;
+    });
 
 /**
  * 홈화면 나의 배틀 현황 조회 (팀 제외)

--- a/src/features/home/hooks/userField/useGetUserFieldHomeTeam.ts
+++ b/src/features/home/hooks/userField/useGetUserFieldHomeTeam.ts
@@ -1,0 +1,24 @@
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {axios} from '../../../../lib/axios';
+import {type IUserFieldHomeTeam} from '../../types/userField';
+
+const fetcher = async (): Promise<IUserFieldHomeTeam> =>
+  await axios.get(`/user-field/home/team`).then(({data}) => data);
+
+/**
+ * 매칭안함
+ *
+ *  홈화면 나의 팀 현황 조회 (팀배틀, 1:1 배틀 제외) 📜
+ * - 매치 시작일부터 오늘까지의 누적 데이터
+ * - 진행 중인 팀이 없을 경우 null 이 반환
+ */
+export const useGetUserFieldHomeTeam = (): UseQueryResult<
+  IUserFieldHomeTeam,
+  Error
+> =>
+  useQuery({
+    queryKey: KEYS.homeTeam(),
+    queryFn: async () => await fetcher(),
+  });

--- a/src/features/home/types/index.ts
+++ b/src/features/home/types/index.ts
@@ -1,0 +1,1 @@
+export * from './userField';

--- a/src/features/home/types/userField.ts
+++ b/src/features/home/types/userField.ts
@@ -3,39 +3,29 @@ import {type TFieldType} from '../../match/types';
 export type TUserFieldBattleType = Exclude<TFieldType, 'TEAM'>;
 
 export interface IUserFieldHomeTeam {
-  /**
-   * 소모 칼로리
-   */
-  burnedCalorie: {
-    name: string;
-    value: number;
-  };
-  /**
-   * 완료까지 남은 날짜
-   */
-  daysLeft: number;
-  /**
-   * 운동시간
-   */
-  exerciseTimeMinute: {
-    name: string;
-    value: number;
-  };
-  /**
-   * 운동시간
-   */
-  fieldId: number;
-  /**
-   * 운동시간
-   */
+  /** 활동링 달성 횟수 */
   goalAchievedCount: {
     name: string;
     value: number;
   };
+  /** 소모 칼로리 */
+  burnedCalorie: {
+    name: string;
+    value: number;
+  };
+  /** 소모 운동 시간 */
+  exerciseTimeMinute: {
+    name: string;
+    value: number;
+  };
+  /** 기록 횟수 */
   recordCount: {
     name: string;
     value: number;
   };
+  /** 완료까지 남은 날짜 */
+  daysLeft: number;
+  fieldId: number;
   teamName: string;
 }
 

--- a/src/features/home/types/userField.ts
+++ b/src/features/home/types/userField.ts
@@ -51,3 +51,5 @@ export interface IUserFieldHomeBattle {
   /** 기록 횟수 */
   totalRecordCount: number;
 }
+
+export type THomeBattleField = Exclude<keyof IUserFieldHomeBattle, 'name'>;

--- a/src/features/home/types/userField.ts
+++ b/src/features/home/types/userField.ts
@@ -1,0 +1,53 @@
+import {type TFieldType} from '../../match/types';
+
+export type TUserFieldBattleType = Exclude<TFieldType, 'TEAM'>;
+
+export interface IUserFieldHomeTeam {
+  /**
+   * 소모 칼로리
+   */
+  burnedCalorie: {
+    name: string;
+    value: number;
+  };
+  /**
+   * 완료까지 남은 날짜
+   */
+  daysLeft: number;
+  /**
+   * 운동시간
+   */
+  exerciseTimeMinute: {
+    name: string;
+    value: number;
+  };
+  /**
+   * 운동시간
+   */
+  fieldId: number;
+  /**
+   * 운동시간
+   */
+  goalAchievedCount: {
+    name: string;
+    value: number;
+  };
+  recordCount: {
+    name: string;
+    value: number;
+  };
+  teamName: string;
+}
+
+export interface IUserFieldHomeBattle {
+  /** 활동링 달성 횟수 */
+  goalAchievedCount: number;
+  /** 성명 */
+  name: string;
+  /** 소모 칼로리 */
+  totalBurnedCalorie: number;
+  /** 소모 운동 시간 */
+  totalExerciseTimeMinute: number;
+  /** 기록 횟수 */
+  totalRecordCount: number;
+}

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -7,6 +7,7 @@ import {
   CurrentWorkoutSection,
   TodayCalorieSection,
   MainBanner,
+  MatchPreviewSection,
 } from '../../features/home/components';
 import {type BottomTabStackParamList} from '../../navigators';
 
@@ -17,6 +18,7 @@ export function HomeScreen({navigation}: Props): React.JSX.Element {
     <ScrollView>
       <MainBanner />
       <TodayCalorieSection />
+      <MatchPreviewSection />
       <CurrentWorkoutSection />
     </ScrollView>
   );


### PR DESCRIPTION
## branch

- `main` <- `feature/home_matching_preview`

## Summary

- 홈(메인)스크린 내 '매칭 탭' 요약 보기 기능을 구현합니다.


|진행 중인 매칭 없는 경우(공통)|1:1 매칭| 팀 매칭 | 매칭안함 |
|:---:|:---:|:---:|:---:|
|![image](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/3d391e5b-f161-4d5c-b08d-1e909a513a04)|![image](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/b4954a54-58fe-4ec8-b36d-024f5dec5244)|![image](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/929b38bf-9d8b-4a97-9a9c-802d363b2690)|![image](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/50926224-f846-4a77-835d-2a242dc29efb)| 
|(모두 목업데이터 예시입니다)|

## Task

- [x] Tab 관련 컴포넌트 추가
  - `ScrollView` 내 `TopTabNavigator` 사용 불가로 인해, `Animated` 기능으로 Tab UI를 구현하였습니다. ([관련 이슈](https://github.com/react-navigation/react-navigation/issues/11067))
- [x] userField home 관련 hook 및 type 추가
- [x] `Tab` 내부 컴포넌트 추가
  - [x] `MatchingPreviewDuelBattleSection(1:1 매칭)` 컴포넌트 추가
  - [x] `MatchingPreviewTeamBattleSection(팀 매칭)` 컴포넌트 추가
  - [x] `MatchingPreviewTeamSection(매칭 안함)` 컴포넌트 추가
- ~~'매칭 이동' 클릭 시 관련 매칭으로 네비게이팅~~ -> 일반 로그인 구현 후, 실제 매칭 신청하여 디버깅 진행하며 추가하겠습니다.

## ETC

- 유의 사항, 참고할 내용을 추가합니다

## Issue Number

- Close #74 