### PR TITLE
✨ feat: 매칭 상세 팀원 탭 - mutate onSuccess, onError Callback 작업

### DIFF
--- a/src/features/match/components/MatchDetailMember/MatchExitButton.tsx
+++ b/src/features/match/components/MatchDetailMember/MatchExitButton.tsx
@@ -1,8 +1,13 @@
-import React from 'react';
+import React, {useState} from 'react';
 
+import {useNavigation} from '@react-navigation/native';
+import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {TouchableOpacity} from 'react-native';
+import Toast from 'react-native-simple-toast';
 
+import {ConfirmModal} from '../../../../components/Modal';
 import {Tag} from '../../../../components/Tag';
+import {type MatchStackParamList} from '../../../../navigators';
 import {useDeleteUserFieldExit} from '../../hooks/userField/useDeleteUserFieldExit';
 
 interface IMatchExitButtonProps {
@@ -12,7 +17,40 @@ interface IMatchExitButtonProps {
 export const MatchExitButton = ({
   id,
 }: IMatchExitButtonProps): React.JSX.Element => {
-  const {mutate: exitField} = useDeleteUserFieldExit();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<MatchStackParamList>>();
+
+  const [modalInfo, setModalInfo] = useState({
+    isVisible: false,
+    title: '',
+    subTitle: '',
+  });
+
+  const {mutate: exitField} = useDeleteUserFieldExit({
+    onSuccessCallback: () => {
+      Toast.show('팀에서 나갔습니다.', Toast.SHORT, {
+        backgroundColor: '#000000c5',
+      });
+      navigation.navigate('MatchList', {
+        page: 0,
+        size: 10,
+        fieldType: 'DUEL',
+        goal: [],
+        memberCount: null,
+        period: [],
+        skillLevel: [],
+        strength: [],
+        keyword: '',
+      });
+    },
+    onErrorCallback: error => {
+      setModalInfo({
+        isVisible: true,
+        title: '팀 나가기',
+        subTitle: error?.response?.data?.message ?? '오류가 발생하였습니다',
+      });
+    },
+  });
 
   const handleExitTag = (): void => {
     exitField({id});
@@ -29,6 +67,14 @@ export const MatchExitButton = ({
         backgroundColor="gray-50"
         borderColor="gray-50"
         text="팀 나가기"
+      />
+      <ConfirmModal
+        visible={modalInfo.isVisible}
+        title={modalInfo.title}
+        subTitle={modalInfo.subTitle}
+        handleConfirm={() => {
+          setModalInfo({isVisible: false, title: '', subTitle: ''});
+        }}
       />
     </TouchableOpacity>
   );

--- a/src/features/match/hooks/field/usePatchChangeLeader.ts
+++ b/src/features/match/hooks/field/usePatchChangeLeader.ts
@@ -3,13 +3,15 @@ import {type UseMutationResult, useMutation} from '@tanstack/react-query';
 import {KEYS} from './keys';
 import {axios} from '../../../../lib/axios';
 import {queryClient} from '../../../../lib/react-query';
+import {type CustomAxiosError} from '../../../../utils/types';
 
 interface IProps {
   id: number;
 }
 
 interface IUsePatchChangeLeaderProps {
-  onSuccessCallback: (id: string) => void;
+  onSuccessCallback: () => void;
+  onErrorCallback: (error: CustomAxiosError) => void;
 }
 
 const fetcher = async ({id}: IProps): Promise<string> =>
@@ -17,12 +19,20 @@ const fetcher = async ({id}: IProps): Promise<string> =>
 
 export const usePatchChangeLeader = ({
   onSuccessCallback,
-}: IUsePatchChangeLeaderProps): UseMutationResult<string, Error, IProps> => {
+  onErrorCallback,
+}: IUsePatchChangeLeaderProps): UseMutationResult<
+  string,
+  CustomAxiosError,
+  IProps
+> => {
   return useMutation({
     mutationFn: fetcher,
     onSuccess: response => {
-      onSuccessCallback(response);
+      onSuccessCallback();
       void queryClient.invalidateQueries(KEYS.all);
+    },
+    onError: error => {
+      onErrorCallback(error);
     },
   });
 };

--- a/src/features/match/hooks/fieldEntry/usePostFieldEntryAccept.ts
+++ b/src/features/match/hooks/fieldEntry/usePostFieldEntryAccept.ts
@@ -1,9 +1,9 @@
 import {useMutation, type UseMutationResult} from '@tanstack/react-query';
-import {type AxiosError} from 'axios';
 
 import {KEYS} from './keys';
 import {axios} from '../../../../lib/axios';
 import {queryClient} from '../../../../lib/react-query';
+import {type CustomAxiosError} from '../../../../utils/types';
 import {KEYS as FIELD_KEYS} from '../field/keys';
 
 interface IProps {
@@ -11,17 +11,19 @@ interface IProps {
 }
 
 interface IUsePostFieldEntryAcceptProps {
-  onSuccessCallback?: () => void;
+  onSuccessCallback: () => void;
+  onErrorCallback: (error: CustomAxiosError) => void;
 }
 
 const fetcher = async ({entryId}: IProps): Promise<string> =>
   await axios.post(`/field-entry/${entryId}/accept`).then(({data}) => data);
 
 export const usePostFieldEntryAccept = ({
-  onSuccessCallback = () => {},
+  onSuccessCallback,
+  onErrorCallback,
 }: IUsePostFieldEntryAcceptProps): UseMutationResult<
   string,
-  AxiosError,
+  CustomAxiosError,
   IProps
 > =>
   useMutation({
@@ -30,5 +32,8 @@ export const usePostFieldEntryAccept = ({
       onSuccessCallback();
       void queryClient.invalidateQueries(KEYS.all);
       void queryClient.fetchInfiniteQuery(FIELD_KEYS.all);
+    },
+    onError: error => {
+      onErrorCallback(error);
     },
   });

--- a/src/features/match/hooks/userField/useDeleteUserFieldEject.ts
+++ b/src/features/match/hooks/userField/useDeleteUserFieldEject.ts
@@ -1,9 +1,9 @@
 import {useMutation, type UseMutationResult} from '@tanstack/react-query';
-import {type AxiosError} from 'axios';
 
 import {KEYS} from './keys';
 import {axios} from '../../../../lib/axios';
 import {queryClient} from '../../../../lib/react-query';
+import {type CustomAxiosError} from '../../../../utils/types';
 
 interface IProps {
   id: number;
@@ -11,7 +11,8 @@ interface IProps {
 }
 
 interface IUseDeleteUserFieldEjectProps {
-  onSuccessCallback?: () => void;
+  onSuccessCallback: () => void;
+  onErrorCallback: (error: CustomAxiosError) => void;
 }
 
 const fetcher = async ({id, ids}: IProps): Promise<string> =>
@@ -21,10 +22,11 @@ const fetcher = async ({id, ids}: IProps): Promise<string> =>
 
 /** DELETE: 팀원 내보내기 */
 export const useDeleteUserFieldEject = ({
-  onSuccessCallback = () => {},
+  onSuccessCallback,
+  onErrorCallback,
 }: IUseDeleteUserFieldEjectProps): UseMutationResult<
   string,
-  AxiosError,
+  CustomAxiosError,
   IProps
 > =>
   useMutation({
@@ -32,5 +34,8 @@ export const useDeleteUserFieldEject = ({
     onSuccess: () => {
       onSuccessCallback();
       void queryClient.invalidateQueries(KEYS.all);
+    },
+    onError: error => {
+      onErrorCallback(error);
     },
   });

--- a/src/features/match/hooks/userField/useDeleteUserFieldExit.ts
+++ b/src/features/match/hooks/userField/useDeleteUserFieldExit.ts
@@ -1,26 +1,38 @@
 import {useMutation, type UseMutationResult} from '@tanstack/react-query';
-import {type AxiosError} from 'axios';
 
 import {KEYS} from './keys';
 import {axios} from '../../../../lib/axios';
 import {queryClient} from '../../../../lib/react-query';
+import {type CustomAxiosError} from '../../../../utils/types';
 
 interface IProps {
   id: number;
+}
+
+interface IUseDeleteUserFieldExitProps {
+  onSuccessCallback: () => void;
+  onErrorCallback: (error: CustomAxiosError) => void;
 }
 
 const fetcher = async ({id}: IProps): Promise<string> =>
   await axios.delete(`/user-field/${id}/exit`).then(({data}) => data);
 
 /** DELETE: 필드 나가기 */
-export const useDeleteUserFieldExit = (): UseMutationResult<
+export const useDeleteUserFieldExit = ({
+  onSuccessCallback,
+  onErrorCallback,
+}: IUseDeleteUserFieldExitProps): UseMutationResult<
   string,
-  AxiosError,
+  CustomAxiosError,
   IProps
 > =>
   useMutation({
     mutationFn: fetcher,
     onSuccess: () => {
+      onSuccessCallback();
       void queryClient.invalidateQueries(KEYS.all);
+    },
+    onError: error => {
+      onErrorCallback(error);
     },
   });

--- a/src/screens/match/detail/matching/MatchDetailMatchingMoreScreen.tsx
+++ b/src/screens/match/detail/matching/MatchDetailMatchingMoreScreen.tsx
@@ -64,6 +64,15 @@ export const MatchDetailMatchingMoreScreen = (): React.JSX.Element => {
       });
       navigation.pop();
     },
+    onErrorCallback: error => {
+      Toast.show(
+        error?.response?.data?.message ?? '알 수 없는 오류가 발생하였습니다.',
+        Toast.SHORT,
+        {
+          backgroundColor: '#000000c5',
+        },
+      );
+    },
   });
 
   const [isSettingMode, setIsSettingMode] = useState(false);

--- a/src/screens/match/detail/member/MatchDetailMemberAssignScreen.tsx
+++ b/src/screens/match/detail/member/MatchDetailMemberAssignScreen.tsx
@@ -1,6 +1,11 @@
 import React, {useState} from 'react';
 
-import {type RouteProp, useRoute} from '@react-navigation/native';
+import {
+  type RouteProp,
+  useRoute,
+  useNavigation,
+} from '@react-navigation/native';
+import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {SafeAreaView, ScrollView, View} from 'react-native';
 import Toast from 'react-native-simple-toast';
 
@@ -12,6 +17,9 @@ import {useGetUserFieldList} from '../../../../features/match/hooks/userField';
 import {type MatchStackParamList} from '../../../../navigators/MatchNavigator';
 
 export const MatchDetailMemberAssignScreen = (): React.JSX.Element => {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<MatchStackParamList>>();
+
   const route =
     useRoute<RouteProp<MatchStackParamList, 'MatchDetailMemberAssign'>>();
 
@@ -21,11 +29,21 @@ export const MatchDetailMemberAssignScreen = (): React.JSX.Element => {
 
   const {data: userFieldData} = useGetUserFieldList({id});
 
-  // TODO: 성공 이후 토스트 메시지 노출 후 navigation pop
   const {mutate: patchChangeLeader} = usePatchChangeLeader({
     onSuccessCallback: () => {
       Toast.show('방장이 변경 되었습니다.', Toast.SHORT, {
         backgroundColor: '#000000c5',
+      });
+      navigation.navigate('MatchList', {
+        page: 0,
+        size: 10,
+        fieldType: 'DUEL',
+        goal: [],
+        memberCount: null,
+        period: [],
+        skillLevel: [],
+        strength: [],
+        keyword: '',
       });
     },
     onErrorCallback: error => {

--- a/src/screens/match/detail/member/MatchDetailMemberAssignScreen.tsx
+++ b/src/screens/match/detail/member/MatchDetailMemberAssignScreen.tsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 
 import {type RouteProp, useRoute} from '@react-navigation/native';
 import {SafeAreaView, ScrollView, View} from 'react-native';
+import Toast from 'react-native-simple-toast';
 
 import {theme} from '../../../../assets/styles/theme';
 import {Button} from '../../../../components/Button';
@@ -22,7 +23,20 @@ export const MatchDetailMemberAssignScreen = (): React.JSX.Element => {
 
   // TODO: 성공 이후 토스트 메시지 노출 후 navigation pop
   const {mutate: patchChangeLeader} = usePatchChangeLeader({
-    onSuccessCallback: () => {},
+    onSuccessCallback: () => {
+      Toast.show('방장이 변경 되었습니다.', Toast.SHORT, {
+        backgroundColor: '#000000c5',
+      });
+    },
+    onErrorCallback: error => {
+      Toast.show(
+        error?.response?.data.message ?? '알 수 없는 오류가 발생하였습니다.',
+        Toast.SHORT,
+        {
+          backgroundColor: '#000000c5',
+        },
+      );
+    },
   });
 
   const handleAssignLeader = (): void => {

--- a/src/screens/match/detail/member/MatchDetailMemberDeleteScreen.tsx
+++ b/src/screens/match/detail/member/MatchDetailMemberDeleteScreen.tsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 
 import {type RouteProp, useRoute} from '@react-navigation/native';
 import {SafeAreaView, ScrollView, View} from 'react-native';
+import Toast from 'react-native-simple-toast';
 
 import {theme} from '../../../../assets/styles/theme';
 import {Button} from '../../../../components/Button';
@@ -20,7 +21,20 @@ export const MatchDetailMemberDeleteScreen = (): React.JSX.Element => {
 
   // TODO: 팀원 삭제 이후 토스트 안내 및 navigation pop
   const {mutate: deleteUserFieldEject} = useDeleteUserFieldEject({
-    onSuccessCallback: () => {},
+    onSuccessCallback: () => {
+      Toast.show('팀원이 삭제 되었습니다.', Toast.SHORT, {
+        backgroundColor: '#000000c5',
+      });
+    },
+    onErrorCallback: error => {
+      Toast.show(
+        error?.response?.data?.message ?? '알 수 없는 오류가 발생하였습니다.',
+        Toast.SHORT,
+        {
+          backgroundColor: '#000000c5',
+        },
+      );
+    },
   });
 
   const {data: userFieldData} = useGetUserFieldList({id});

--- a/src/screens/match/detail/member/MatchDetailMemberRequestAcceptScreen.tsx
+++ b/src/screens/match/detail/member/MatchDetailMemberRequestAcceptScreen.tsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 
 import {type RouteProp, useRoute} from '@react-navigation/native';
 import {SafeAreaView, ScrollView, View} from 'react-native';
+import Toast from 'react-native-simple-toast';
 
 import {theme} from '../../../../assets/styles/theme';
 import {Button} from '../../../../components/Button';
@@ -21,20 +22,30 @@ export const MatchDetailMemberRequestAcceptScreen = (): React.JSX.Element => {
   const [checkedMember, setCheckedMember] = useState<number[]>([]);
 
   const {mutate: postFieldEntryAccept} = usePostFieldEntryAccept({
-    onSuccessCallback: () => {},
+    onSuccessCallback: () => {
+      Toast.show('팀원 요청을 수락하였습니다.', Toast.SHORT, {
+        backgroundColor: '#000000c5',
+      });
+    },
+    onErrorCallback: error => {
+      Toast.show(
+        error?.response?.data?.message ?? '알 수 없는 오류가 발생하였습니다.',
+        Toast.SHORT,
+        {
+          backgroundColor: '#000000c5',
+        },
+      );
+    },
   });
 
   const {data: userFieldData} = useGetFieldEntryTeam({id, size: 10, page: 0});
 
   const handleRequestAccept = (): void => {
-    // TODO: 해당 API 사용 방식 논의 중
-    postFieldEntryAccept({entryId: checkedMember});
+    postFieldEntryAccept({entryId: checkedMember[0]});
   };
 
   const handleCheckMember = (id: number): void => {
-    checkedMember.includes(id)
-      ? setCheckedMember(value => [...value.filter(value => value !== id)])
-      : setCheckedMember(value => [...value, id]);
+    checkedMember.includes(id) ? setCheckedMember([]) : setCheckedMember([id]);
   };
 
   return (


### PR DESCRIPTION
## branch

- `main` <- `feature/member-callback`

## Summary

- 매칭 상세 팀원 탭에 대해 mutate 성공, 실패 상황에 대한 작업을 마쳤습니다. 

  - 우선 서버에서 보내주는 에러 메시지를 활용하는 방식으로 진행하였습니다.

| useDeleteUserFieldExit | usePatchChangeLeader | useDeleteUserFieldEject |
|--------|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-15 at 22 23 43](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/bddf40f5-9fc6-4e54-b7c4-448babaa9212) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-15 at 22 23 52](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/1ae47726-990f-4b96-a9d1-b873274c4f08) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-15 at 22 24 00](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/c7261866-f9c6-401f-92fb-3f5d09328f6e) | 

## Task



- [x] 팀 나가기 onSuccessCallback, onErrorCallback (`useDeleteUserFieldExit`)
- [x] 방장 넘기기 onSuccessCallback, onErrorCallback (`usePatchChangeLeader`)
- [x] 팀 요청 수락 onSuccessCallback, onErrorCallback (`usePostFieldEntryAccept`)
- [x] 팀원 제거 onSuccessCallback, onErrorCallback (`useDeleteUserFieldEject`)

## ETC

- 현재 기능 별로 mutate onSuccess, onError 에 따라 동작이 다릅니다. (`토스트 노출` or `모달 노출` or `navigate 이동`을 요구하는 로직) 따라서 callBack 으로 넘겨주는 방식으로 진행하였습니다. 더 좋은 방식이 있다면 피드백 부탁드립니다 👍

- 팀원 요청 수락 기능에 이슈가 있는 것 같아 #92 작업하면서 함께 보겠습니다! 

- 서버 error 메시지 사용 관련해서 [노션](https://www.notion.so/seonhye0113/user-field-id-exit-85864a380194460b84b748744d237e15?pvs=4)에 남겨두었는데, 논의가 필요할 것으로 보입니다 🤔

## Issue Number

- Close #91 
