### PR TITLE
✨ feat: 일반 로그인 스크린 추가

### DIFF
--- a/src/features/auth/hooks/auth/usePostLogin.ts
+++ b/src/features/auth/hooks/auth/usePostLogin.ts
@@ -2,6 +2,8 @@ import {type UseMutationResult, useMutation} from '@tanstack/react-query';
 
 import {ASYNC_STORAGE_KEYS, asyncStorage} from '../../../../lib/asyncStorage';
 import {axios} from '../../../../lib/axios';
+import Toast from '../../../../lib/toast';
+import {type CustomAxiosError} from '../../../../utils/types';
 
 interface IProps {
   body: {
@@ -38,6 +40,10 @@ export const usePostLogin = (): UseMutationResult<
         ASYNC_STORAGE_KEYS.AUTH_JWT_REFRESH_TOKEN,
         refreshToken,
       );
+    },
+    onError: (error: CustomAxiosError) => {
+      if (error.response?.data.message == null) return;
+      Toast.show({message: error.response?.data.message});
     },
   });
 };

--- a/src/features/auth/hooks/auth/usePostLogin.ts
+++ b/src/features/auth/hooks/auth/usePostLogin.ts
@@ -17,6 +17,11 @@ interface IReturnType {
   refreshToken: string;
 }
 
+interface IQueryOptions {
+  onSuccess?: (data: IReturnType) => void;
+  onError?: (error: CustomAxiosError) => void;
+}
+
 const fetcher = async ({body}: IProps): Promise<IReturnType> =>
   await axios
     .post(`/auth/login`, body, {
@@ -24,11 +29,9 @@ const fetcher = async ({body}: IProps): Promise<IReturnType> =>
     })
     .then(({data}) => data);
 
-export const usePostLogin = (): UseMutationResult<
-  IReturnType,
-  Error,
-  IProps
-> => {
+export const usePostLogin = (
+  options?: IQueryOptions,
+): UseMutationResult<IReturnType, CustomAxiosError, IProps> => {
   return useMutation({
     mutationFn: fetcher,
     onSuccess: ({accessToken, refreshToken}) => {
@@ -40,10 +43,17 @@ export const usePostLogin = (): UseMutationResult<
         ASYNC_STORAGE_KEYS.AUTH_JWT_REFRESH_TOKEN,
         refreshToken,
       );
+
+      options?.onSuccess?.({accessToken, refreshToken});
     },
-    onError: (error: CustomAxiosError) => {
-      if (error.response?.data.message == null) return;
-      Toast.show({message: error.response?.data.message});
+    onError: error => {
+      const message =
+        error.response != null
+          ? error.response?.data.message
+          : '로그인에 실패하였습니다.';
+      Toast.show({message});
+
+      options?.onError?.(error);
     },
   });
 };

--- a/src/features/home/components/MatchPreviewSection/MatchingPreviewTeamSection.tsx
+++ b/src/features/home/components/MatchPreviewSection/MatchingPreviewTeamSection.tsx
@@ -16,7 +16,6 @@ import {useGetUserFieldHomeTeam} from '../../hooks/userField';
 export const MatchingPreviewTeamSection = (): React.JSX.Element => {
   const {data: userFieldHomeTeam} = useGetUserFieldHomeTeam();
   const {data: myProfileDetail} = useGetMyProfileDetail();
-  console.log('userFieldHomeTeam', userFieldHomeTeam);
 
   return (
     <>

--- a/src/features/home/hooks/userField/useGetUserFieldHomeTeam.ts
+++ b/src/features/home/hooks/userField/useGetUserFieldHomeTeam.ts
@@ -5,7 +5,10 @@ import {axios} from '../../../../lib/axios';
 import {type IUserFieldHomeTeam} from '../../types/userField';
 
 const fetcher = async (): Promise<IUserFieldHomeTeam> =>
-  await axios.get(`/user-field/home/team`).then(({data}) => data);
+  await axios.get(`/user-field/home/team`).then(({data}) => {
+    if (data === '') return null;
+    return data;
+  });
 
 /**
  * 매칭안함

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,48 @@
+import {type ColorValue} from 'react-native';
+import _Toast from 'react-native-simple-toast';
+
+interface IStylesIOS {
+  textColor?: ColorValue;
+  backgroundColor?: ColorValue;
+}
+
+interface IShowOption {
+  message: string;
+  duration?: number;
+  gravity?: number;
+  xOffset?: number;
+  yOffset?: number;
+  styles?: IStylesIOS;
+}
+
+const DEFAULT_IOS_TOAST_STYLES: IStylesIOS = {
+  textColor: undefined,
+  backgroundColor: 'rgba(0, 0, 0, 0.6)',
+};
+
+const DEFAULT_OFFSET_X: number = 0;
+const DEFAULT_OFFSET_Y: number = -70;
+
+const show = ({
+  message,
+  duration = _Toast.SHORT,
+  gravity = _Toast.BOTTOM,
+  xOffset = DEFAULT_OFFSET_X,
+  yOffset = DEFAULT_OFFSET_Y,
+  styles = DEFAULT_IOS_TOAST_STYLES,
+}: IShowOption): void => {
+  _Toast.showWithGravityAndOffset(
+    message,
+    duration,
+    gravity,
+    xOffset,
+    yOffset,
+    styles,
+  );
+};
+
+const Toast = {
+  show,
+};
+
+export default Toast;

--- a/src/navigators/AppNavigator.tsx
+++ b/src/navigators/AppNavigator.tsx
@@ -34,7 +34,13 @@ export function AppNavigator(): React.JSX.Element {
             headerShown: false,
           }}
         />
-        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen
+          name="Login"
+          component={LoginScreen}
+          options={{
+            headerShown: false,
+          }}
+        />
         <Stack.Screen
           name="Signup"
           component={SignupScreen}

--- a/src/screens/auth/LandingScreen.tsx
+++ b/src/screens/auth/LandingScreen.tsx
@@ -117,9 +117,26 @@ export function LandingScreen({navigation}: Props): React.JSX.Element {
                   />
                 </StyledTextButton>
                 <Text text="|" type="body2" color="gray-600" fontWeight="500" />
-                <StyledTextButton>
+                <StyledTextButton
+                  onPress={() => {
+                    setShowBottomModal(false);
+                    // TODO(@minimalKim): 비밀번호 찾기 스크린 추가
+                  }}>
                   <Text
                     text="비밀번호 찾기"
+                    type="body2"
+                    color="gray-600"
+                    fontWeight="500"
+                  />
+                </StyledTextButton>
+                <Text text="|" type="body2" color="gray-600" fontWeight="500" />
+                <StyledTextButton
+                  onPress={() => {
+                    setShowBottomModal(false);
+                    navigation.push('Login');
+                  }}>
+                  <Text
+                    text="일반 로그인"
                     type="body2"
                     color="gray-600"
                     fontWeight="500"

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -75,11 +75,16 @@ export const LoginScreen = ({navigation}: Props): React.JSX.Element => {
           }}>
           <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
         </StyledBackButton>
-
-        <Text type="head3" text="일반 로그인" />
       </StyledTopBar>
 
       <StyledSection>
+        <Text
+          text="일반 로그인"
+          type="head3"
+          fontWeight="600"
+          style={{paddingTop: 32}}
+        />
+
         <StyledFieldContainer>
           <Controller
             control={control}
@@ -176,29 +181,33 @@ export const LoginScreen = ({navigation}: Props): React.JSX.Element => {
 
 const StyledTopBar = styled.View`
   display: flex;
-  margin: 50px 16px;
+  flex-direction: row;
+  padding: 20px 16px;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 const StyledBackButton = styled.TouchableOpacity`
   width: 32px;
-  margin-bottom: 32px;
 `;
 
 const StyledSection = styled.View`
+  display: flex;
   flex-direction: column;
   flex: 1;
   background-color: white;
+  padding: 0 16px;
 `;
 
 const StyledFieldContainer = styled.View`
-  padding: 0 16px;
   gap: 20px;
-  height: 220px;
+  padding-top: 42px;
+  padding-bottom: 32px;
 `;
 
 const ButtonWrapper = styled.View`
   width: 100%;
-  padding: 20px;
+  padding: 4px;
 `;
 
 const StyledTextButton = styled.TouchableOpacity`

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -45,7 +45,11 @@ export const LoginScreen = ({navigation}: Props): React.JSX.Element => {
     resolver: zodResolver(validationSchema),
   });
 
-  const {mutate: postLogin} = usePostLogin();
+  const {mutate: postLogin} = usePostLogin({
+    onSuccess: () => {
+      navigation.navigate('Landing');
+    },
+  });
 
   const handlePressSubmit = async (): Promise<void> => {
     const isUidValid = await trigger('uid');
@@ -58,8 +62,6 @@ export const LoginScreen = ({navigation}: Props): React.JSX.Element => {
         password: getValues('password'),
       },
     });
-
-    navigation.navigate('Main');
   };
 
   return (
@@ -78,12 +80,7 @@ export const LoginScreen = ({navigation}: Props): React.JSX.Element => {
       </StyledTopBar>
 
       <StyledSection>
-        <Text
-          text="일반 로그인"
-          type="head3"
-          fontWeight="600"
-          style={{paddingTop: 32}}
-        />
+        <Text text="일반 로그인" type="head3" fontWeight="600" />
 
         <StyledFieldContainer>
           <Controller
@@ -196,7 +193,7 @@ const StyledSection = styled.View`
   flex-direction: column;
   flex: 1;
   background-color: white;
-  padding: 0 16px;
+  padding: 32px 16px 0;
 `;
 
 const StyledFieldContainer = styled.View`

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -1,22 +1,216 @@
-import React from 'react';
+import React, {useState} from 'react';
 
+import styled from '@emotion/native';
+import {zodResolver} from '@hookform/resolvers/zod';
 import {type NativeStackScreenProps} from '@react-navigation/native-stack';
-import {SafeAreaView, Text, Button} from 'react-native';
+import {Controller, useForm} from 'react-hook-form';
+import {Pressable, SafeAreaView} from 'react-native';
+import {z} from 'zod';
 
+import {
+  arrowLeftXmlData,
+  eyeClosedXmlData,
+  eyeOpenedXmlData,
+} from '../../assets/svg';
+import {Button} from '../../components/Button';
+import {Icon} from '../../components/Icon';
+import {Text} from '../../components/Text';
+import {Textfield} from '../../components/Textfield/Textfield';
+import {usePostLogin} from '../../features/auth/hooks/auth';
 import {type RootStackParamList} from '../../navigators';
+
+const validationSchema = z.object({
+  uid: z
+    .string()
+    .min(6, {message: '6자 이상으로 입력해주세요'})
+    .refine(value => /^(?=.*[a-zA-Z])(?=.*\d).+$/.test(value), {
+      message: '최소 1자 이상의 영문과 숫자를 포함해주세요',
+    }),
+  password: z
+    .string()
+    .min(8, {message: '비밀번호를 8글자 이상으로 입력해주세요'})
+    .max(16, {message: '비밀번호를 16글자 이하로 입력해주세요'})
+    .refine(value => /^(?=.*[a-zA-Z])(?=.*\d).+$/.test(value), {
+      message: '최소 1자 이상의 영문과 숫자를 포함해주세요',
+    }),
+});
+
+type ValidationSchema = z.infer<typeof validationSchema>;
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Login'>;
 
-export function LoginScreen({navigation}: Props): React.JSX.Element {
+export const LoginScreen = ({navigation}: Props): React.JSX.Element => {
+  const [isSecureTextEntry, setIsSecureTextEntry] = useState(true);
+  const {control, trigger, formState, getValues} = useForm<ValidationSchema>({
+    resolver: zodResolver(validationSchema),
+  });
+
+  const {mutate: postLogin} = usePostLogin();
+
+  const handlePressSubmit = async (): Promise<void> => {
+    const isUidValid = await trigger('uid');
+    const isPasswordValid = await trigger('password');
+    if (!isUidValid || !isPasswordValid) return;
+
+    postLogin({
+      body: {
+        uid: getValues('uid'),
+        password: getValues('password'),
+      },
+    });
+
+    navigation.navigate('Main');
+  };
+
   return (
-    <SafeAreaView>
-      <Text>LoginScreen</Text>
-      <Button
-        title="기록하기"
-        onPress={() => {
-          navigation.replace('Main');
-        }}
-      />
+    <SafeAreaView
+      style={{
+        backgroundColor: 'white',
+        flex: 1,
+      }}>
+      <StyledTopBar>
+        <StyledBackButton
+          onPress={() => {
+            navigation.pop();
+          }}>
+          <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
+        </StyledBackButton>
+
+        <Text type="head3" text="일반 로그인" />
+      </StyledTopBar>
+
+      <StyledSection>
+        <StyledFieldContainer>
+          <Controller
+            control={control}
+            name="uid"
+            rules={{
+              required: '아이디를 입력해주세요',
+            }}
+            render={({field: {onChange, onBlur, value}}) => (
+              <Textfield
+                label="아이디"
+                textContentType="nickname"
+                isError={formState.errors.uid != null}
+                value={value}
+                errorMessage={formState.errors.uid?.message}
+                onBlur={onBlur}
+                onChangeText={onChange}
+              />
+            )}
+          />
+
+          <Controller
+            control={control}
+            name="password"
+            rules={{
+              required: '비밀번호를 입력해주세요',
+            }}
+            render={({field: {onChange, onBlur, value}}) => (
+              <Textfield
+                label="비밀번호"
+                placeholder="영문, 숫자를 포함하여 입력해주세요."
+                textContentType="password"
+                secureTextEntry={isSecureTextEntry}
+                maxLength={16}
+                value={value}
+                isError={formState.errors.password != null}
+                errorMessage={formState.errors.password?.message}
+                onBlur={onBlur}
+                onChangeText={onChange}
+                rightElement={() => (
+                  <Pressable
+                    onPress={() => {
+                      setIsSecureTextEntry(prev => !prev);
+                    }}>
+                    <Icon
+                      svgXml={
+                        isSecureTextEntry ? eyeClosedXmlData : eyeOpenedXmlData
+                      }
+                    />
+                  </Pressable>
+                )}
+              />
+            )}
+          />
+        </StyledFieldContainer>
+        <ButtonWrapper>
+          <Button
+            text="로그인하기"
+            disabled={!formState.isValid}
+            style={{borderRadius: 12}}
+            onPress={() => {
+              void handlePressSubmit();
+            }}
+          />
+          <StyledHorizontalView>
+            <StyledTextButton
+              onPress={() => {
+                navigation.push('FindId');
+              }}>
+              <Text
+                text="아이디 찾기"
+                type="body2"
+                color="gray-600"
+                fontWeight="500"
+              />
+            </StyledTextButton>
+            <Text text="|" type="body2" color="gray-600" fontWeight="500" />
+            <StyledTextButton
+              onPress={() => {
+                // TODO(@minimalKim): 비밀번호 찾기 스크린 추가
+              }}>
+              <Text
+                text="비밀번호 찾기"
+                type="body2"
+                color="gray-600"
+                fontWeight="500"
+              />
+            </StyledTextButton>
+          </StyledHorizontalView>
+        </ButtonWrapper>
+      </StyledSection>
     </SafeAreaView>
   );
-}
+};
+
+const StyledTopBar = styled.View`
+  display: flex;
+  margin: 50px 16px;
+`;
+
+const StyledBackButton = styled.TouchableOpacity`
+  width: 32px;
+  margin-bottom: 32px;
+`;
+
+const StyledSection = styled.View`
+  flex-direction: column;
+  flex: 1;
+  background-color: white;
+`;
+
+const StyledFieldContainer = styled.View`
+  padding: 0 16px;
+  gap: 20px;
+  height: 220px;
+`;
+
+const ButtonWrapper = styled.View`
+  width: 100%;
+  padding: 20px;
+`;
+
+const StyledTextButton = styled.TouchableOpacity`
+  margin-top: 16px;
+  margin-bottom: 14px;
+  padding: 6px;
+`;
+
+const StyledHorizontalView = styled.View`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+`;


### PR DESCRIPTION
## branch

- `develop` <- `feat/OOO`

## Summary

- 일반 로그인 스크린을 추가합니다.



| 로그인 화면 | 로그인 화면 (서버 에러 메세지) | 
|:---:|:---:|
|![image](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/ee9cbe7d-875a-49c3-a4e4-df8857476583)|![image](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/5952dfa5-0980-4b63-a171-b50337406621)|

## Task

- [x] `LoginScreen(일반 로그인)` 추가 및 api 연동
- [x] toast lib 코드 추가
  -  현재 사용하는 toast가 모두 유사한 스타일과 위치로 사용하는 것 같아, 기본 스타일 값을 제공하는 lib 코드를 추가하였습니다.




## ETC

- Main 화면 진입 시, useGetUserFieldHomeTeam api 빈 스트링 처리가 되지 않아 타입 에러가 발생하여, 해당 처리를 추가하였습니다. ([관련 문의](https://www.notion.so/seonhye0113/Front-Back-e96f51ba9d734d4cbe1cc2aee02d7aa2?pvs=4))

## Issue Number

- Close #100 
