### PR TITLE
✨ feat: notification 컴포넌트 추가 및 NotificationScreen 추가

### DIFF
--- a/src/features/home/components/MainBanner.tsx
+++ b/src/features/home/components/MainBanner.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 
 import styled from '@emotion/native';
+import {useNavigation} from '@react-navigation/native';
+import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {StatusBar, TouchableOpacity, View} from 'react-native';
 
 import {alarmXmlData} from '../../../assets/svg';
 import {Icon} from '../../../components/Icon';
 import {Text} from '../../../components/Text';
+import {type HomeStackParamList} from '../../../navigators';
 import {useGetUserFieldProgress} from '../../match/hooks/userField';
 import {useGetMyProfileDetail} from '../../my/hooks/profile';
 
@@ -13,13 +16,19 @@ export const MainBanner = (): React.JSX.Element => {
   const {data: userFieldProgress} = useGetUserFieldProgress();
   const {data: myProfileDetail} = useGetMyProfileDetail();
 
+  const navigation =
+    useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
+
   return (
     <StyledTopBanner>
       <StatusBar barStyle="light-content" />
 
       <View>
         <StyledIconWrapper>
-          <TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => {
+              navigation.navigate('Notification');
+            }}>
             <Icon svgXml={alarmXmlData} width={24} height={24} />
           </TouchableOpacity>
         </StyledIconWrapper>

--- a/src/features/notification/components/NotificationList.tsx
+++ b/src/features/notification/components/NotificationList.tsx
@@ -1,0 +1,99 @@
+import React, {useMemo} from 'react';
+
+import styled from '@emotion/native';
+
+import {NotificationListItem} from './NotificationListItem';
+import {Text} from '../../../components/Text';
+import {dayjs} from '../../../lib/dayjs';
+import {type INotification} from '../types';
+
+interface INotificationListProps {
+  notifications: INotification[];
+  isPressMoreVisible?: boolean;
+  onPressMore?: () => void;
+  onPressNotification?: (notification: INotification) => void;
+}
+
+type IGroupedNotifications = Record<string, INotification[]>;
+
+export const NotificationList = ({
+  notifications,
+  isPressMoreVisible,
+  onPressMore,
+  onPressNotification,
+}: INotificationListProps): React.JSX.Element => {
+  const groupedNotificationsByDate = useMemo(() => {
+    const groupedData: IGroupedNotifications = {};
+
+    for (const notification of notifications) {
+      const date = dayjs(notification.createdAt).format('YYYY-MM-DD');
+      if (groupedData[date] === undefined) {
+        groupedData[date] = [];
+      }
+      groupedData[date].push(notification);
+    }
+
+    return groupedData;
+  }, [notifications]);
+
+  return (
+    <StyledContainer>
+      <StyledNotificationList>
+        {Object.entries(groupedNotificationsByDate).map(
+          ([date, notifications]) => (
+            <>
+              <StyledNotificationDate>
+                <Text color="gray-400" text={dayjs(date).format('M월D일')} />
+              </StyledNotificationDate>
+
+              {notifications.map((notification, i) => (
+                <NotificationListItem
+                  key={`${notification.id}-${i}`}
+                  isRead={notification.isRead}
+                  isLast={notifications.length - 1 === i}
+                  content="test"
+                  onPress={() => {
+                    onPressNotification?.(notification);
+                  }}
+                />
+              ))}
+            </>
+          ),
+        )}
+      </StyledNotificationList>
+
+      {isPressMoreVisible != null && (
+        <StyledMoreButton onPress={onPressMore}>
+          <Text text="더보기" type="body3" fontWeight="600" color="gray-600" />
+        </StyledMoreButton>
+      )}
+    </StyledContainer>
+  );
+};
+
+const StyledContainer = styled.View`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledNotificationList = styled.View`
+  display: flex;
+  align-items: center;
+  width: 100%;
+`;
+
+const StyledNotificationDate = styled.View`
+  display: flex;
+  padding: 34px 18px 10px;
+  align-items: flex-start;
+  width: 100%;
+  border-bottom-width: 0.5px;
+  border-color: ${({theme}) => theme.palette['gray-300']};
+`;
+
+const StyledMoreButton = styled.TouchableOpacity`
+  border-radius: 16px;
+  background-color: ${({theme}) => theme.palette['gray-100']};
+  padding: 16px 60px;
+  margin: 20px 0;
+`;

--- a/src/features/notification/components/NotificationList.tsx
+++ b/src/features/notification/components/NotificationList.tsx
@@ -63,6 +63,7 @@ export const NotificationList = ({
       </StyledNotificationList>
 
       {isPressMoreVisible != null && (
+        // TODO(@minimalKim): 더보기 버튼 디자인 명세 필요
         <StyledMoreButton onPress={onPressMore}>
           <Text text="더보기" type="body3" fontWeight="600" color="gray-600" />
         </StyledMoreButton>

--- a/src/features/notification/components/NotificationListItem.tsx
+++ b/src/features/notification/components/NotificationListItem.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+
+import {Text} from '../../../components/Text';
+
+interface INotificationListItemProps {
+  isRead: boolean;
+  isLast: boolean;
+  content: string;
+  onPress?: () => void;
+}
+
+export const NotificationListItem = ({
+  isRead,
+  isLast,
+  content,
+  onPress,
+}: INotificationListItemProps): React.JSX.Element => {
+  const Container =
+    onPress != null
+      ? StyledNotificationListItemPressable
+      : StyledNotificationListItem;
+
+  return (
+    <Container isRead={isRead} isLast={isLast} onPress={onPress}>
+      <Text text={content} type="body2"></Text>
+    </Container>
+  );
+};
+
+const StyledNotificationListItemPressable = styled.TouchableOpacity<{
+  isRead: boolean;
+  isLast: boolean;
+}>`
+  display: flex;
+  padding: 18px 68px;
+  border-width: 0.5px;
+  border-bottom-width: ${({isLast}) => (isLast ? '1px' : '0.5px')};
+  border-color: ${({theme}) => theme.palette['gray-300']};
+  background-color: ${({theme, isRead}) =>
+    isRead ? theme.palette['gray-0'] : 'rgba(179, 242, 218, 0.2)'};
+  width: 100%;
+`;
+
+const StyledNotificationListItem = styled.View<{
+  isRead: boolean;
+  isLast: boolean;
+}>`
+  display: flex;
+  padding: 18px 68px;
+  border-width: 0.5px;
+  border-bottom-width: ${({isLast}) => (isLast ? '1px' : '0.5px')};
+  border-color: ${({theme}) => theme.palette['gray-300']};
+  width: 100%;
+`;

--- a/src/features/notification/components/index.ts
+++ b/src/features/notification/components/index.ts
@@ -1,0 +1,1 @@
+export * from './NotificationList';

--- a/src/features/notification/hooks/index.ts
+++ b/src/features/notification/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useGetNotificationUser';
+export * from './usePatchNotificationUserRead';

--- a/src/features/notification/hooks/keys.ts
+++ b/src/features/notification/hooks/keys.ts
@@ -1,0 +1,4 @@
+export const KEYS = {
+  all: ['notification'] as const,
+  user: () => [...KEYS.all, 'user'],
+};

--- a/src/features/notification/hooks/useGetNotificationUser.ts
+++ b/src/features/notification/hooks/useGetNotificationUser.ts
@@ -5,46 +5,7 @@ import {
 
 import {KEYS} from './keys';
 import {axios} from '../../../lib/axios';
-import {dayjs} from '../../../lib/dayjs';
 import {type INotificationResponse, type IHomeNotification} from '../types';
-
-interface DummyData {
-  currentPageNumber: number;
-  currentPageSize: number;
-  totalCount: number;
-  notificationInfos: IHomeNotification[];
-}
-
-function generateDummyData(
-  pageNumber: number = 1,
-  pageSize: number = 10,
-): DummyData {
-  const dummyData: DummyData = {
-    currentPageNumber: pageNumber,
-    currentPageSize: pageSize,
-    totalCount: 0,
-    notificationInfos: [] as any[],
-  };
-
-  const startDate = dayjs('2023-11-26 12:11:02', {
-    format: 'YYYY-MM-DD HH:mm:ss',
-  });
-  const endDate = dayjs(startDate).add(pageNumber - 1, 'day');
-
-  for (let i = 1; i <= pageSize; i++) {
-    const newNotification = {
-      content: `Notification ${i}`,
-      createdAt: endDate.format('YYYY-MM-DD HH:mm:ss'),
-      fieldId: 100 + i + pageNumber,
-      id: Date.now(),
-      isRead: pageNumber > 2,
-    };
-    dummyData.notificationInfos.push(newNotification);
-    startDate.add(1, 'day');
-  }
-
-  return dummyData;
-}
 
 export interface IGetNotificationUserParams {
   offset?: number;
@@ -57,11 +18,7 @@ type TGetNotificationUserResponse = INotificationResponse<IHomeNotification>;
 const fetcher = async (
   params: IGetNotificationUserParams,
 ): Promise<TGetNotificationUserResponse> =>
-  await axios
-    .get('/notification/user', {
-      params,
-    })
-    .then(() => generateDummyData(params.pageNumber, params.pageSize));
+  await axios.get('/notification/user', {params});
 
 export const useGetNotificationUser = (
   params: IGetNotificationUserParams,

--- a/src/features/notification/hooks/useGetNotificationUser.ts
+++ b/src/features/notification/hooks/useGetNotificationUser.ts
@@ -1,0 +1,80 @@
+import {
+  useInfiniteQuery,
+  type UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {axios} from '../../../lib/axios';
+import {dayjs} from '../../../lib/dayjs';
+import {type INotificationResponse, type IHomeNotification} from '../types';
+
+interface DummyData {
+  currentPageNumber: number;
+  currentPageSize: number;
+  totalCount: number;
+  notificationInfos: IHomeNotification[];
+}
+
+function generateDummyData(
+  pageNumber: number = 1,
+  pageSize: number = 10,
+): DummyData {
+  const dummyData: DummyData = {
+    currentPageNumber: pageNumber,
+    currentPageSize: pageSize,
+    totalCount: 0,
+    notificationInfos: [] as any[],
+  };
+
+  const startDate = dayjs('2023-11-26 12:11:02', {
+    format: 'YYYY-MM-DD HH:mm:ss',
+  });
+  const endDate = dayjs(startDate).add(pageNumber - 1, 'day');
+
+  for (let i = 1; i <= pageSize; i++) {
+    const newNotification = {
+      content: `Notification ${i}`,
+      createdAt: endDate.format('YYYY-MM-DD HH:mm:ss'),
+      fieldId: 100 + i + pageNumber,
+      id: Date.now(),
+      isRead: pageNumber > 2,
+    };
+    dummyData.notificationInfos.push(newNotification);
+    startDate.add(1, 'day');
+  }
+
+  return dummyData;
+}
+
+export interface IGetNotificationUserParams {
+  offset?: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
+type TGetNotificationUserResponse = INotificationResponse<IHomeNotification>;
+
+const fetcher = async (
+  params: IGetNotificationUserParams,
+): Promise<TGetNotificationUserResponse> =>
+  await axios
+    .get('/notification/user', {
+      params,
+    })
+    .then(() => generateDummyData(params.pageNumber, params.pageSize));
+
+export const useGetNotificationUser = (
+  params: IGetNotificationUserParams,
+): UseInfiniteQueryResult<TGetNotificationUserResponse, Error> =>
+  useInfiniteQuery({
+    queryKey: KEYS.user(),
+    queryFn: async ({pageParam = 1}) =>
+      await fetcher({...params, pageNumber: pageParam}),
+    getNextPageParam: lastPage => {
+      const {notificationInfos, currentPageNumber} = lastPage;
+      return notificationInfos.length < params.pageSize
+        ? undefined
+        : currentPageNumber + 1;
+    },
+    cacheTime: 0,
+  });

--- a/src/features/notification/hooks/usePatchNotificationUserRead.tsx
+++ b/src/features/notification/hooks/usePatchNotificationUserRead.tsx
@@ -1,0 +1,20 @@
+import {type UseMutationResult, useMutation} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {axios} from '../../../lib/axios';
+import {queryClient} from '../../../lib/react-query';
+
+const fetcher = async (): Promise<string> =>
+  await axios.patch(`/notification/user/read`).then(({data}) => data);
+
+export const usePatchNotificationUserRead = (): UseMutationResult<
+  string,
+  Error
+> => {
+  return useMutation({
+    mutationFn: fetcher,
+    onSuccess: () => {
+      void queryClient.invalidateQueries(KEYS.user());
+    },
+  });
+};

--- a/src/features/notification/types/index.ts
+++ b/src/features/notification/types/index.ts
@@ -1,0 +1,1 @@
+export * from './notification';

--- a/src/features/notification/types/notification.ts
+++ b/src/features/notification/types/notification.ts
@@ -1,0 +1,20 @@
+export interface INotification {
+  content: string;
+  createdAt: string;
+  id: number;
+  isRead: boolean;
+  fieldId?: number;
+}
+
+export interface IFieldNotification extends Omit<INotification, 'fieldId'> {}
+
+export interface IHomeNotification extends INotification {
+  fieldId: number;
+}
+
+export interface INotificationResponse<T extends INotification> {
+  currentPageNumber: number;
+  currentPageSize: number;
+  totalCount: number;
+  notificationInfos: T[];
+}

--- a/src/navigators/BottomTabNavigator.tsx
+++ b/src/navigators/BottomTabNavigator.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 
+import {HomeNavigator} from './HomeNavigator';
 import {MatchNavigator} from './MatchNavigator';
 import {RecordNavigator} from './RecordNavigator';
 import {theme} from '../assets/styles/theme';
@@ -13,11 +14,11 @@ import {
 } from '../assets/svg';
 import {Icon} from '../components/Icon';
 import {Text} from '../components/Text';
-import {HomeScreen} from '../screens/home';
 import {MyScreen} from '../screens/my';
 
 export type BottomTabStackParamList = {
   Home: undefined;
+  Notification: undefined;
   Records: undefined;
   Match: undefined;
   My: undefined;
@@ -49,7 +50,7 @@ export function BottomTabNavigator(): React.JSX.Element {
       }}>
       <Tab.Screen
         name="Home"
-        component={HomeScreen}
+        component={HomeNavigator}
         options={{
           headerShown: false,
           tabBarLabel: ({focused}) => (

--- a/src/navigators/HomeNavigator.tsx
+++ b/src/navigators/HomeNavigator.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import {createNativeStackNavigator} from '@react-navigation/native-stack';
+
+import {HomeScreen, NotificationScreen} from '../screens/home';
+
+export type HomeStackParamList = {
+  HomeMain: undefined;
+  Notification: undefined;
+};
+
+const Stack = createNativeStackNavigator<HomeStackParamList>();
+
+export function HomeNavigator(): React.JSX.Element {
+  return (
+    <Stack.Navigator initialRouteName="HomeMain">
+      <Stack.Screen
+        name="HomeMain"
+        component={HomeScreen}
+        options={{
+          headerShown: false,
+        }}
+      />
+      <Stack.Screen
+        name="Notification"
+        component={NotificationScreen}
+        options={{
+          headerShown: false,
+        }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigators/index.ts
+++ b/src/navigators/index.ts
@@ -1,3 +1,4 @@
 export * from './AppNavigator';
 export * from './BottomTabNavigator';
 export * from './MatchNavigator';
+export * from './HomeNavigator';

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
 
-import {type BottomTabScreenProps} from '@react-navigation/bottom-tabs';
+import {type NativeStackScreenProps} from '@react-navigation/native-stack';
 import {ScrollView} from 'react-native';
 
+import {theme} from '../../assets/styles/theme';
 import {
   CurrentWorkoutSection,
   TodayCalorieSection,
   MainBanner,
   MatchPreviewSection,
 } from '../../features/home/components';
-import {type BottomTabStackParamList} from '../../navigators';
+import {type HomeStackParamList} from '../../navigators';
 
-type Props = BottomTabScreenProps<BottomTabStackParamList, 'Home'>;
+type Props = NativeStackScreenProps<HomeStackParamList, 'HomeMain'>;
 
 export function HomeScreen({navigation}: Props): React.JSX.Element {
   return (
-    <ScrollView>
+    <ScrollView style={{backgroundColor: theme.palette['gray-0']}}>
       <MainBanner />
       <TodayCalorieSection />
       <MatchPreviewSection />

--- a/src/screens/home/NotificationScreen.tsx
+++ b/src/screens/home/NotificationScreen.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+import {type NativeStackScreenProps} from '@react-navigation/native-stack';
+import {SafeAreaView, ScrollView, StatusBar, View} from 'react-native';
+
+import {theme} from '../../assets/styles/theme';
+import {Text} from '../../components/Text';
+import {NotificationList} from '../../features/notification/components';
+import {
+  useGetNotificationUser,
+  usePatchNotificationUserRead,
+} from '../../features/notification/hooks';
+import {type HomeStackParamList} from '../../navigators';
+
+type Props = NativeStackScreenProps<HomeStackParamList, 'Notification'>;
+
+export function NotificationScreen({navigation}: Props): React.JSX.Element {
+  const {
+    data: notificationUser,
+    hasNextPage,
+    fetchNextPage,
+  } = useGetNotificationUser({
+    pageSize: 10,
+    pageNumber: 1,
+  });
+
+  const {mutate: patchNotificationUserRead} = usePatchNotificationUserRead();
+
+  return (
+    <>
+      <StatusBar barStyle="default" />
+      <SafeAreaView />
+      <StyledTopBar>
+        <StyledTopBarButton
+          onPress={() => {
+            navigation.pop();
+          }}>
+          <Text text="뒤로" type="body3" color="gray-400" />
+        </StyledTopBarButton>
+
+        <Text text="알림" type="body2" fontWeight="700" />
+
+        <StyledTopBarButton
+          onPress={() => {
+            patchNotificationUserRead(undefined);
+            navigation.pop();
+          }}>
+          <Text text="모두 읽기" type="body3" color="gray-400" />
+        </StyledTopBarButton>
+      </StyledTopBar>
+
+      <ScrollView style={{backgroundColor: theme.palette['gray-0']}}>
+        <View>
+          <NotificationList
+            notifications={
+              notificationUser?.pages.flatMap(page => page.notificationInfos) ??
+              []
+            }
+            isPressMoreVisible={hasNextPage}
+            onPressMore={() => {
+              void fetchNextPage();
+            }}
+            onPressNotification={notification => {
+              if (notification.fieldId != null) {
+                // TODO(@minimalKim): 필드 페이지로 이동
+                console.log(notification);
+              }
+            }}
+          />
+        </View>
+      </ScrollView>
+    </>
+  );
+}
+
+const StyledTopBar = styled.View`
+  display: flex;
+  flex-direction: row;
+  padding: 16px;
+  align-items: center;
+  justify-content: space-between;
+  background-color: ${({theme}) => theme.palette['gray-0']};
+`;
+
+const StyledTopBarButton = styled.TouchableOpacity`
+  min-width: 60px;
+  display: flex;
+  align-items: center;
+`;

--- a/src/screens/home/index.ts
+++ b/src/screens/home/index.ts
@@ -1,1 +1,2 @@
 export * from './HomeScreen';
+export * from './NotificationScreen';


### PR DESCRIPTION
## branch

- `main` <- `feature/user_notification2`

## Summary

-  notification 컴포넌트 추가 및 Home 화면의 `NotificationScreen`을 추가합니다.

<img src="https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/58e7ae7e-3790-485d-86cc-4f0e4293ae13"  width="300">


## Task

- notification(알림) 관련 feature component, hook, type을 추가합니다.
  - [x] 공통 알림 내역 디자인 사용을 위한 NotificationList 컴포넌트 추가
  - [x] user notification hook 추가 및 연동
  
- Notification 스크린을 추가합니다.
  -  [x] `HomeNavigator` 추가
  -  [x] `HomeScreen`에서 `NotificationScreen` 네비게이트 추가


## Issue Number
- 알림 무한스크롤로 많은 내역을 조회한 상태에서 뒤로가기 후 스크린 재진입 시, cache된 페이지 모두 한꺼번에 요청을 보내는 이슈가 있습니다. (ex. 20페이지 까지 조회 이후 재진입시, 초기 pageNumber 부터 시작하지 않고 한꺼번에 20번의 api가 보내지는 이슈)
  - 위 이슈를 해결하기 위해 query에 `cacheTime: 0` 옵션이 추가되었습니다.

- Close #107
