### PR TITLE
✨ feat: 자동 로그인 및 401 에러 핸들링 기능 추가

### DIFF
--- a/src/features/auth/hooks/auth/index.ts
+++ b/src/features/auth/hooks/auth/index.ts
@@ -2,3 +2,4 @@ export * from './useGetAuthIdAvailable';
 export * from './usePostSignup';
 export * from './usePostLogin';
 export * from './usePostAuthChangePassword';
+export * from './usePostRefreshAccessToken';

--- a/src/features/auth/hooks/auth/usePostRefreshAccessToken.ts
+++ b/src/features/auth/hooks/auth/usePostRefreshAccessToken.ts
@@ -1,0 +1,46 @@
+import {type UseMutationResult, useMutation} from '@tanstack/react-query';
+
+import {ASYNC_STORAGE_KEYS, asyncStorage} from '../../../../lib/asyncStorage';
+import {axios} from '../../../../lib/axios';
+import {type CustomAxiosError} from '../../../../utils/types';
+
+interface IProps {
+  body: {
+    refreshToken: string;
+  };
+}
+
+interface IReturnType {
+  accessToken: string;
+}
+
+interface IMutationOptions {
+  onSuccessCallback?: (data: IReturnType) => void;
+  onErrorCallback?: (error: CustomAxiosError) => void;
+}
+
+export const requestPostAuthRefresh = async ({
+  body,
+}: IProps): Promise<IReturnType> =>
+  await axios
+    .post(`/auth/refresh`, body, {
+      headers: {'Content-Type': 'application/json'},
+    })
+    .then(({data}) => data);
+
+export const usePostRefreshAccessToken = (
+  options?: IMutationOptions,
+): UseMutationResult<IReturnType, CustomAxiosError, IProps> => {
+  return useMutation({
+    mutationFn: requestPostAuthRefresh,
+    onSuccess: ({accessToken}) => {
+      void asyncStorage.set(
+        ASYNC_STORAGE_KEYS.AUTH_JWT_ACCESS_TOKEN,
+        accessToken,
+      );
+
+      options?.onSuccessCallback?.({accessToken});
+    },
+    onError: options?.onErrorCallback,
+  });
+};

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -64,7 +64,9 @@ const handle401Error = async (
       // 유효하지 않은 (잘못된) JWT 토큰 (J-001)
       // 지원하지 않는 JWT 토큰 (J-003)
       // - 재로그인
-      appNavigationRef.navigate('Login');
+      if (appNavigationRef.isReady()) {
+        appNavigationRef.navigate('Login');
+      }
       break;
     }
     case 'J-002': {

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,6 +1,9 @@
-import Axios from 'axios';
+import Axios, {type AxiosResponse} from 'axios';
 
 import {asyncStorage, ASYNC_STORAGE_KEYS} from './asyncStorage';
+import {requestPostAuthRefresh} from '../features/auth/hooks/auth';
+import {appNavigationRef} from '../navigators';
+import {type CustomAxiosError} from '../utils/types';
 
 // TODO: env 관련 설정 추가
 export const API_URL = '/api';
@@ -45,9 +48,50 @@ axios.interceptors.request.use(async config => {
 axios.interceptors.response.use(undefined, async error => {
   if (Axios.isAxiosError(error)) {
     const statusCode = error.response?.status;
-    if (statusCode === 401 || statusCode === 403) {
-      // TODO: 재로그인
+    if (statusCode === 401) {
+      void handle401Error(error);
     }
   }
   return await Promise.reject(error);
 });
+
+const handle401Error = async (
+  error: CustomAxiosError,
+): Promise<AxiosResponse<any, any> | undefined> => {
+  switch (error.code) {
+    case 'J-001':
+    case 'J-003': {
+      // 유효하지 않은 (잘못된) JWT 토큰 (J-001)
+      // 지원하지 않는 JWT 토큰 (J-003)
+      // - 재로그인
+      appNavigationRef.navigate('Login');
+      break;
+    }
+    case 'J-002': {
+      // 만료된 토큰(J-002)
+      // - 토큰 재발급
+      const refreshToken = await asyncStorage.get<string>(
+        ASYNC_STORAGE_KEYS.AUTH_JWT_REFRESH_TOKEN,
+      );
+
+      if (refreshToken != null) {
+        const {accessToken} = await requestPostAuthRefresh({
+          body: {
+            refreshToken,
+          },
+        });
+
+        await asyncStorage.set<string>(
+          ASYNC_STORAGE_KEYS.AUTH_JWT_ACCESS_TOKEN,
+          accessToken,
+        );
+
+        if (error.config != null) {
+          error.config.headers.Authorization = `Bearer ${accessToken}`;
+          return await axios(error.config);
+        }
+      }
+      break;
+    }
+  }
+};

--- a/src/navigators/AppNavigator.tsx
+++ b/src/navigators/AppNavigator.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import {NavigationContainer} from '@react-navigation/native';
+import {
+  NavigationContainer,
+  createNavigationContainerRef,
+} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 
 import {BottomTabNavigator} from './BottomTabNavigator';
@@ -25,9 +28,12 @@ export type RootStackParamList = {
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
+export const appNavigationRef =
+  createNavigationContainerRef<RootStackParamList>();
+
 export function AppNavigator(): React.JSX.Element {
   return (
-    <NavigationContainer>
+    <NavigationContainer ref={appNavigationRef}>
       <Stack.Navigator initialRouteName="Landing">
         <Stack.Screen
           name="Landing"

--- a/src/screens/auth/LandingScreen.tsx
+++ b/src/screens/auth/LandingScreen.tsx
@@ -31,7 +31,7 @@ export function LandingScreen({navigation}: Props): React.JSX.Element {
 
   const {mutate: postRefreshAccessToken} = usePostRefreshAccessToken({
     onSuccessCallback: () => {
-      navigation.navigate('Main');
+      navigation.replace('Main');
     },
   });
 

--- a/src/screens/auth/LandingScreen.tsx
+++ b/src/screens/auth/LandingScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import styled from '@emotion/native';
 import {type NativeStackScreenProps} from '@react-navigation/native-stack';
@@ -13,19 +13,45 @@ import {BottomSheet} from '../../components/BottomSheet';
 import {Button} from '../../components/Button';
 import {Icon} from '../../components/Icon';
 import {Text} from '../../components/Text';
+import {usePostRefreshAccessToken} from '../../features/auth/hooks/auth';
+import {asyncStorage} from '../../lib/asyncStorage';
 import {type RootStackParamList} from '../../navigators';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Landing'>;
 
 export function LandingScreen({navigation}: Props): React.JSX.Element {
   const [showBottomModal, setShowBottomModal] = useState(false);
-  const [isLogin, setIsLogin] = useState(false);
+  const [isSelectedLogin, setIsSelectedLogin] = useState(false);
 
   const getSnsButtonLabel = (sns: string): string => {
     return `${sns === 'Apple' ? `${sns}로` : sns} ${
-      isLogin ? '로그인' : '계속하기'
+      isSelectedLogin ? '로그인' : '계속하기'
     }`;
   };
+
+  const {mutate: postRefreshAccessToken} = usePostRefreshAccessToken({
+    onSuccessCallback: () => {
+      navigation.navigate('Main');
+    },
+  });
+
+  const refreshAccessToken = async (): Promise<void> => {
+    const refreshToken = await asyncStorage.get<string>(
+      'auth-jwt-refresh-token',
+    );
+
+    if (refreshToken != null) {
+      postRefreshAccessToken({
+        body: {
+          refreshToken,
+        },
+      });
+    }
+  };
+
+  useEffect(() => {
+    void refreshAccessToken();
+  }, []);
 
   return (
     <StyledSafeAreaView>
@@ -40,7 +66,7 @@ export function LandingScreen({navigation}: Props): React.JSX.Element {
           style={{borderRadius: 16}}
           onPress={() => {
             setShowBottomModal(true);
-            setIsLogin(true);
+            setIsSelectedLogin(true);
           }}
         />
         <Button
@@ -52,7 +78,7 @@ export function LandingScreen({navigation}: Props): React.JSX.Element {
           }}
           onPress={() => {
             setShowBottomModal(true);
-            setIsLogin(false);
+            setIsSelectedLogin(false);
           }}
         />
       </StyledButtonContainer>
@@ -102,7 +128,7 @@ export function LandingScreen({navigation}: Props): React.JSX.Element {
               </StyledSnsButton>
             </StyledSnsButtonContainer>
 
-            {isLogin ? (
+            {isSelectedLogin ? (
               <StyledHorizontalView>
                 <StyledTextButton
                   onPress={() => {


### PR DESCRIPTION
## branch

- `main` <- `feature/refresh_token`

## Summary

- Landing Screen 마운트 시, asyncStorage에 refreshToken 있을 경우, accessToken 재발급 및 재등록(자동 로그인) 기능을 추가합니다.
  - 재발급 성공 시, MainScreen(Home)으로 이동 합니다.
- axios 401 에러 응답에 대한 에러 핸들링 코드를 추가합니다.
  - 유효하지 않거나 지원하지 않는 JWT 토큰 -> 로그인 페이지로 이동
  - 만료된 토큰일 경우 -> accessToken 재발급 및 재등록

## Task

- Landing Screen 마운트 시 기존 로그인 유저인 경우, 자동 로그인 기능 추가
- axios 401 에러 핸들링 추가


## Issue Number

- Close #99 
