### PR TITLE
✨ feat: Stack Navigator Header 커스텀 작업

### DIFF
--- a/src/components/Header/HeaderBackButton.tsx
+++ b/src/components/Header/HeaderBackButton.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import {useNavigation} from '@react-navigation/native';
+import {TouchableOpacity} from 'react-native';
+
+import {arrowLeftXmlData} from '../../assets/svg';
+import {Icon} from '../Icon';
+
+export const HeaderBackButton = (): React.JSX.Element => {
+  const navigation = useNavigation();
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.8}
+      onPress={() => {
+        navigation.goBack();
+      }}>
+      <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
+    </TouchableOpacity>
+  );
+};

--- a/src/components/Header/HeaderTitle.tsx
+++ b/src/components/Header/HeaderTitle.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+
+import {Text} from '../Text';
+
+interface IHeaderTitleProps {
+  title?: string;
+}
+
+export const HeaderTitle = ({
+  title = '',
+}: IHeaderTitleProps): React.JSX.Element => {
+  return (
+    <StyledHeaderWrapper>
+      <Text type="body1" fontWeight="700" textAlign="center" text={title} />
+    </StyledHeaderWrapper>
+  );
+};
+
+const StyledHeaderWrapper = styled.View`
+  height: 48px;
+  justify-content: center;
+`;

--- a/src/components/Header/index.ts
+++ b/src/components/Header/index.ts
@@ -1,0 +1,2 @@
+export * from './HeaderBackButton';
+export * from './HeaderTitle';

--- a/src/navigators/MatchNavigator.tsx
+++ b/src/navigators/MatchNavigator.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
+import {type RouteProp, useRoute} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import {TouchableOpacity} from 'react-native';
 
+import {detailAlarmXmlData} from '../assets/svg';
+import {HeaderBackButton, HeaderTitle} from '../components/Header';
+import {Icon} from '../components/Icon';
 import {
   type TUserRole,
   type IFieldListPaginationParams,
@@ -38,18 +43,17 @@ import {MatchFilterScreen} from '../screens/match/list';
 
 export type MatchStackParamList = {
   MatchList: IFieldListPaginationParams;
-  // 필터 화면
   MatchFilter: IFieldListParams;
-  // 팀 생성 화면
   TeamInformation: undefined;
   TeamProfile: undefined;
-  // 자동 매칭 화면
   AutoMatch: undefined;
   AutoMatchResult: {
     fieldType: 'DUEL' | 'TEAM_BATTLE';
   };
-  // 팀 상세 화면
   MatchDetail: {
+    id: number;
+  };
+  MatchDetailAlarm: {
     id: number;
   };
   MatchDetailProfileSetting: {
@@ -102,7 +106,14 @@ const Stack = createNativeStackNavigator<MatchStackParamList>();
 
 export function MatchNavigator(): React.JSX.Element {
   return (
-    <Stack.Navigator initialRouteName="MatchList">
+    <Stack.Navigator
+      initialRouteName="MatchList"
+      screenOptions={{
+        headerBackTitleVisible: false,
+        headerShadowVisible: false,
+        headerTitle: () => <HeaderTitle />,
+        headerLeft: () => <HeaderBackButton />,
+      }}>
       <Stack.Screen
         name="MatchList"
         component={MatchScreen}
@@ -122,66 +133,83 @@ export function MatchNavigator(): React.JSX.Element {
           matchStatus: 'APPLICATION',
         }}
       />
-      <Stack.Screen name="MatchFilter" component={MatchFilterScreen} />
+      <Stack.Screen
+        name="MatchFilter"
+        component={MatchFilterScreen}
+        options={{
+          headerTitle: () => <HeaderTitle title="매칭 필터" />,
+        }}
+      />
       <Stack.Screen
         name="TeamInformation"
         component={CreateMatchInformationScreen}
-        options={{headerTitle: '팀 정보 입력'}}
+        options={{
+          headerTitle: () => <HeaderTitle title="팀 정보 입력" />,
+        }}
       />
       <Stack.Screen
         name="TeamProfile"
         component={CreateMatchProfileScreen}
-        options={{headerTitle: '팀 프로필', headerBackTitleVisible: false}}
+        options={{
+          headerTitle: () => <HeaderTitle title="팀 프로필" />,
+        }}
       />
-      <Stack.Screen
-        name="AutoMatch"
-        component={AutoMatchScreen}
-        options={{headerTitle: ''}}
-      />
-      <Stack.Screen
-        name="AutoMatchResult"
-        component={AutoMatchResultScreen}
-        options={{headerTitle: ''}}
-      />
+      <Stack.Screen name="AutoMatch" component={AutoMatchScreen} />
+      <Stack.Screen name="AutoMatchResult" component={AutoMatchResultScreen} />
       <Stack.Screen
         name="MatchDetail"
         component={MatchDetailScreen}
-        options={{headerTitle: ''}}
+        options={{
+          headerRight: () => {
+            const {params} =
+              useRoute<RouteProp<MatchStackParamList, 'MatchDetail'>>();
+
+            return (
+              <TouchableOpacity
+                onPress={() => {
+                  // TODO(@chajuhui123) : 알림 상세 화면으로 연동
+                  console.log(params.id);
+                }}
+                style={{marginRight: 4}}>
+                <Icon svgXml={detailAlarmXmlData} width={24} height={24} />
+              </TouchableOpacity>
+            );
+          },
+        }}
       />
       <Stack.Screen
         name="MatchDetailProfileSetting"
         component={MatchDetailProfileSettingScreen}
-        options={{headerTitle: ''}}
       />
       <Stack.Screen
         name="UpdateInformation"
         component={UpdateTeamInformationScreen}
-        options={{headerTitle: '팀 정보 수정'}}
+        options={{
+          headerTitle: () => <HeaderTitle title="팀 정보 수정" />,
+        }}
       />
       <Stack.Screen
         name="UpdateProfile"
         component={UpdateTeamProfileScreen}
-        options={{headerTitle: '팀 프로필 수정'}}
+        options={{
+          headerTitle: () => <HeaderTitle title="팀 프로필 수정" />,
+        }}
       />
       <Stack.Screen
         name="MatchDetailRecordDetail"
         component={MatchDetailRecordDetailScreen}
-        options={{headerTitle: ''}}
       />
       <Stack.Screen
         name="MatchDetailRecordSummary"
         component={MatchDetailRecordSummaryScreen}
-        options={{headerTitle: ''}}
       />
       <Stack.Screen
         name="MatchDetailMatchingMore"
         component={MatchDetailMatchingMoreScreen}
-        options={{headerTitle: ''}}
       />
       <Stack.Screen
         name="MatchDetailMemberMore"
         component={MatchDetailMemberMoreScreen}
-        options={{headerTitle: ''}}
         initialParams={{
           type: 'REQUEST',
         }}
@@ -189,17 +217,14 @@ export function MatchNavigator(): React.JSX.Element {
       <Stack.Screen
         name="MatchDetailMemberRequestAccept"
         component={MatchDetailMemberRequestAcceptScreen}
-        options={{headerTitle: ''}}
       />
       <Stack.Screen
         name="MatchDetailMemberAssign"
         component={MatchDetailMemberAssignScreen}
-        options={{headerTitle: ''}}
       />
       <Stack.Screen
         name="MatchDetailMemberDelete"
         component={MatchDetailMemberDeleteScreen}
-        options={{headerTitle: ''}}
       />
     </Stack.Navigator>
   );


### PR DESCRIPTION
## branch

- `main` <- `feature/header-option`

## Summary

- Stack Navigator option 을 활용하여 헤더 커스텀 작업을 진행하였습니다. 

| headerTitle 있는 경우 | headerTitle 없는 경우, headerRight 개별 세팅 |
|--------|--------|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-11-24 at 15 29 58](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/e62c985a-4612-4116-9f3d-e1c64dade6b8) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-11-24 at 15 29 35](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/57554421/3f28ecd6-a0e4-4060-9ad3-a99f612bd8f8) | 




## Task

- [x] HeaderBackButton 컴포넌트 생성
- [x] HeaderTitle 컴포넌트 생성
- [x] Stack option 세팅

## ETC

- 매칭별 알림 화면 연동 작업은 #124 이슈로 분리하여 진행하겠습니다.

- `Stack.Navigator` 에서 기본적으로 옵션값을 세팅한 후, 개별 `Stack.Screen` option 을 커스텀하는 방식으로 진행하였습니다.
  ```js
  screenOptions={{
      headerBackTitleVisible: false,
      headerShadowVisible: false,
      headerTitle: () => <HeaderTitle />,
      headerLeft: () => <HeaderBackButton />,
  }}>
  ```

## Issue Number

- Close #148 
