### PR TITLE
🐛 fix: useGetFieldEntryTeam 데이터 노출 이슈 해결

### DIFF
--- a/src/features/match/components/MatchDetailMember/MatchMemberList.tsx
+++ b/src/features/match/components/MatchDetailMember/MatchMemberList.tsx
@@ -114,11 +114,15 @@ export const MatchMemberList = ({
             isSettingMode={isSettingMode}
             memberInfo={memberInfo}
             isCheck={checkedMember.includes(
-              type === 'REQUEST' ? memberInfo?.entryId : memberInfo?.id,
+              type === 'REQUEST'
+                ? (memberInfo as ITeamEntry)?.entryId
+                : (memberInfo as IUserField)?.id,
             )}
             onPressCheckBox={() => {
               onPressCheckMember(
-                type === 'REQUEST' ? memberInfo?.entryId : memberInfo?.id,
+                type === 'REQUEST'
+                  ? (memberInfo as ITeamEntry)?.entryId
+                  : (memberInfo as IUserField)?.id,
               );
             }}
           />

--- a/src/screens/match/detail/member/MatchDetailMemberMoreScreen.tsx
+++ b/src/screens/match/detail/member/MatchDetailMemberMoreScreen.tsx
@@ -15,22 +15,31 @@ export const MatchDetailMemberMoreScreen = (): React.JSX.Element => {
 
   const {id, type, userRole} = route.params;
 
-  const {data: userFieldData} =
-    type === 'MEMBER'
-      ? useGetUserFieldList({id})
-      : useGetFieldEntryTeam({id, size: 10, page: 0});
+  const {data: userFieldData} = useGetUserFieldList({id});
+  const {data: fieldEntryData} = useGetFieldEntryTeam({id, size: 10, page: 0});
 
   return (
     <SafeAreaView style={{flex: 1, backgroundColor: theme.palette['gray-0']}}>
       <ScrollView>
-        <MatchMemberList
-          id={id}
-          userRole={userRole}
-          type={type}
-          isSummary={false}
-          members={userFieldData}
-          onPressMore={() => {}}
-        />
+        {type === 'MEMBER' ? (
+          <MatchMemberList
+            id={id}
+            userRole={userRole}
+            type={type}
+            isSummary={false}
+            members={userFieldData}
+            onPressMore={() => {}}
+          />
+        ) : (
+          <MatchMemberList
+            id={id}
+            userRole={userRole}
+            type={type}
+            isSummary={false}
+            members={fieldEntryData?.pages.map(page => page.teamEntries).flat()}
+            onPressMore={() => {}}
+          />
+        )}
       </ScrollView>
     </SafeAreaView>
   );

--- a/src/screens/match/detail/member/MatchDetailMemberRequestAcceptScreen.tsx
+++ b/src/screens/match/detail/member/MatchDetailMemberRequestAcceptScreen.tsx
@@ -52,7 +52,7 @@ export const MatchDetailMemberRequestAcceptScreen = (): React.JSX.Element => {
           type="REQUEST"
           isSummary={false}
           isSettingMode={true}
-          members={userFieldData}
+          members={userFieldData?.pages.map(page => page.teamEntries).flat()}
           checkedMember={checkedMember}
           onPressCheckMember={handleCheckMember}
         />


### PR DESCRIPTION
## branch

- `main` <- `fix/field-entry-team`

## Summary

- 팀원 요청 목록 데이터가 목록에 노출 되지 않는 이슈 원인을 파악하고, 해결하였습니다.

## Task

- [x] MathMemberList 컴포넌트 type 에러 수정
- [x] useGetFieldEntryTeam 인피니티 스크롤 데이터 flat 으로 적용

## ETC

- 해당 버그 픽스 머지 이후, #151 에서 RN FlatList 활용하는 방식으로 리팩토링 진행하겠습니다. 

## Issue Number

- Close #92 
