### PR TITLE
 🐛 fix: TeamWorkRateInfo(불꽃 레벨 설명 스크린) TopBar 사용으로 변경

### DIFF
--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import styled from '@emotion/native';
+import {useNavigation} from '@react-navigation/native';
 
 import {arrowLeftXmlData} from '../../assets/svg';
 import {Icon} from '../Icon';
@@ -21,13 +22,19 @@ export const TopBar = ({
   leftComponent,
   rightComponent,
 }: ITopBarProps): React.JSX.Element => {
+  const navigation = useNavigation();
+
+  const handlePressBackButton = (): void => {
+    onPressBackButton?.();
+    navigation.goBack();
+  };
   return (
     <StyledTopBar>
       <StyledLeftWrapper>
         {leftComponent != null ? (
           leftComponent()
         ) : showBackButton ? (
-          <StyledBackButton onPress={onPressBackButton}>
+          <StyledBackButton onPress={handlePressBackButton}>
             <Icon svgXml={arrowLeftXmlData} width={32} height={32} />
           </StyledBackButton>
         ) : (

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
 import styled from '@emotion/native';
+import {useNavigation} from '@react-navigation/native';
+import {SafeAreaView} from 'react-native';
 
+import {theme} from '../../assets/styles/theme';
 import {arrowLeftXmlData} from '../../assets/svg';
 import {Icon} from '../Icon';
 import {Text} from '../Text';
@@ -21,24 +24,34 @@ export const TopBar = ({
   leftComponent,
   rightComponent,
 }: ITopBarProps): React.JSX.Element => {
+  const navigation = useNavigation();
+
+  const handlePressBackButton = (): void => {
+    onPressBackButton?.();
+    navigation.goBack();
+  };
+
   return (
-    <StyledTopBar>
-      <StyledLeftWrapper>
-        {leftComponent != null ? (
-          leftComponent()
-        ) : showBackButton ? (
-          <StyledBackButton onPress={onPressBackButton}>
-            <Icon svgXml={arrowLeftXmlData} width={32} height={32} />
-          </StyledBackButton>
-        ) : (
-          <></>
-        )}
-      </StyledLeftWrapper>
+    <>
+      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
+      <StyledTopBar>
+        <StyledLeftWrapper>
+          {leftComponent != null ? (
+            leftComponent()
+          ) : showBackButton ? (
+            <StyledBackButton onPress={handlePressBackButton}>
+              <Icon svgXml={arrowLeftXmlData} width={32} height={32} />
+            </StyledBackButton>
+          ) : (
+            <></>
+          )}
+        </StyledLeftWrapper>
 
-      <Text text={headerText ?? ''} type="body1" fontWeight="bold" />
+        <Text text={headerText ?? ''} type="body1" fontWeight="bold" />
 
-      <StyledRightWrapper>{rightComponent?.()}</StyledRightWrapper>
-    </StyledTopBar>
+        <StyledRightWrapper>{rightComponent?.()}</StyledRightWrapper>
+      </StyledTopBar>
+    </>
   );
 };
 

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
 import styled from '@emotion/native';
-import {useNavigation} from '@react-navigation/native';
-import {SafeAreaView} from 'react-native';
 
-import {theme} from '../../assets/styles/theme';
 import {arrowLeftXmlData} from '../../assets/svg';
 import {Icon} from '../Icon';
 import {Text} from '../Text';
@@ -24,34 +21,24 @@ export const TopBar = ({
   leftComponent,
   rightComponent,
 }: ITopBarProps): React.JSX.Element => {
-  const navigation = useNavigation();
-
-  const handlePressBackButton = (): void => {
-    onPressBackButton?.();
-    navigation.goBack();
-  };
-
   return (
-    <>
-      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
-      <StyledTopBar>
-        <StyledLeftWrapper>
-          {leftComponent != null ? (
-            leftComponent()
-          ) : showBackButton ? (
-            <StyledBackButton onPress={handlePressBackButton}>
-              <Icon svgXml={arrowLeftXmlData} width={32} height={32} />
-            </StyledBackButton>
-          ) : (
-            <></>
-          )}
-        </StyledLeftWrapper>
+    <StyledTopBar>
+      <StyledLeftWrapper>
+        {leftComponent != null ? (
+          leftComponent()
+        ) : showBackButton ? (
+          <StyledBackButton onPress={onPressBackButton}>
+            <Icon svgXml={arrowLeftXmlData} width={32} height={32} />
+          </StyledBackButton>
+        ) : (
+          <></>
+        )}
+      </StyledLeftWrapper>
 
-        <Text text={headerText ?? ''} type="body1" fontWeight="bold" />
+      <Text text={headerText ?? ''} type="body1" fontWeight="bold" />
 
-        <StyledRightWrapper>{rightComponent?.()}</StyledRightWrapper>
-      </StyledTopBar>
-    </>
+      <StyledRightWrapper>{rightComponent?.()}</StyledRightWrapper>
+    </StyledTopBar>
   );
 };
 

--- a/src/navigators/MyNavigator.tsx
+++ b/src/navigators/MyNavigator.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 
-import {HeaderBackButton, HeaderTitle} from '../components/Header';
 import {
   MyProfileModifyScreen,
   MyProfileScreen,
@@ -85,8 +84,7 @@ export function MyNavigator(): React.JSX.Element {
         name="TeamWorkRateInfo"
         component={TeamWorkRateInfo}
         options={{
-          headerLeft: () => <HeaderBackButton />,
-          headerTitle: () => <HeaderTitle title="불꽃 히스토리" />,
+          headerShown: false,
         }}
       />
     </Stack.Navigator>

--- a/src/screens/my/MyScreen.tsx
+++ b/src/screens/my/MyScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {useNavigation} from '@react-navigation/native';
 import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {View, StatusBar, TouchableOpacity} from 'react-native';
+import {SafeAreaView, StatusBar, TouchableOpacity} from 'react-native';
 
 import {theme} from '../../assets/styles/theme';
 import {Line} from '../../components/Line';
@@ -16,7 +16,7 @@ export function MyScreen(): React.JSX.Element {
     useNavigation<NativeStackNavigationProp<MyStackParamList>>();
 
   return (
-    <View style={{backgroundColor: theme.palette['gray-0'], flex: 1}}>
+    <SafeAreaView style={{backgroundColor: theme.palette['gray-0'], flex: 1}}>
       <StatusBar barStyle="dark-content" />
       <TopBar
         rightComponent={() => (
@@ -33,6 +33,6 @@ export function MyScreen(): React.JSX.Element {
       <Line size="sm" color="gray-50" />
 
       <TeamworkRateSection />
-    </View>
+    </SafeAreaView>
   );
 }

--- a/src/screens/my/MyScreen.tsx
+++ b/src/screens/my/MyScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {useNavigation} from '@react-navigation/native';
 import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {SafeAreaView, StatusBar, TouchableOpacity} from 'react-native';
+import {View, StatusBar, TouchableOpacity} from 'react-native';
 
 import {theme} from '../../assets/styles/theme';
 import {Line} from '../../components/Line';
@@ -16,7 +16,7 @@ export function MyScreen(): React.JSX.Element {
     useNavigation<NativeStackNavigationProp<MyStackParamList>>();
 
   return (
-    <SafeAreaView style={{backgroundColor: theme.palette['gray-0'], flex: 1}}>
+    <View style={{backgroundColor: theme.palette['gray-0'], flex: 1}}>
       <StatusBar barStyle="dark-content" />
       <TopBar
         rightComponent={() => (
@@ -33,6 +33,6 @@ export function MyScreen(): React.JSX.Element {
       <Line size="sm" color="gray-50" />
 
       <TeamworkRateSection />
-    </SafeAreaView>
+    </View>
   );
 }

--- a/src/screens/my/TeamWorkRateInfo.tsx
+++ b/src/screens/my/TeamWorkRateInfo.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 
 import styled from '@emotion/native';
-import {SafeAreaView} from 'react-native';
 
 import {theme} from '../../assets/styles/theme';
 import {fireScoreXmlData} from '../../assets/svg';
 import {Gap} from '../../components/Gap';
 import {Icon} from '../../components/Icon';
 import {Text} from '../../components/Text';
+import {TopBar} from '../../components/TopBar';
 import {FLAMES} from '../../features/my/const';
 
 export const TeamWorkRateInfo = (): React.JSX.Element => {
   return (
     <>
-      <SafeAreaView />
+      <TopBar showBackButton headerText="불꽃 히스토리" />
       <StyledScrollView>
         <StyledVertical style={{padding: 18, paddingTop: 30}}>
           <StyledVertical gap={8}>

--- a/src/screens/my/TeamWorkRateInfo.tsx
+++ b/src/screens/my/TeamWorkRateInfo.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import styled from '@emotion/native';
+import {SafeAreaView} from 'react-native';
 
 import {theme} from '../../assets/styles/theme';
 import {fireScoreXmlData} from '../../assets/svg';
@@ -13,6 +14,7 @@ import {FLAMES} from '../../features/my/const';
 export const TeamWorkRateInfo = (): React.JSX.Element => {
   return (
     <>
+      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
       <TopBar showBackButton headerText="불꽃 히스토리" />
       <StyledScrollView>
         <StyledVertical style={{padding: 18, paddingTop: 30}}>

--- a/src/screens/my/profile/MyProfileModifyScreen.tsx
+++ b/src/screens/my/profile/MyProfileModifyScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from '@react-navigation/native';
 import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {type UseFormReturn, useForm} from 'react-hook-form';
-import {SafeAreaView, TouchableOpacity} from 'react-native';
+import {TouchableOpacity, View} from 'react-native';
 import {z} from 'zod';
 
 import {theme} from '../../../assets/styles/theme';
@@ -78,13 +78,10 @@ export function MyProfileModifyScreen(): React.JSX.Element {
 
   return (
     <>
-      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
+      <View style={{backgroundColor: theme.palette['gray-0']}} />
       <TopBar
         headerText="프로필 편집"
         showBackButton
-        onPressBackButton={() => {
-          navigation.pop();
-        }}
         rightComponent={() => (
           <TouchableOpacity
             onPress={() => {

--- a/src/screens/my/profile/MyProfileModifyScreen.tsx
+++ b/src/screens/my/profile/MyProfileModifyScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from '@react-navigation/native';
 import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {type UseFormReturn, useForm} from 'react-hook-form';
-import {TouchableOpacity, View} from 'react-native';
+import {SafeAreaView, TouchableOpacity} from 'react-native';
 import {z} from 'zod';
 
 import {theme} from '../../../assets/styles/theme';
@@ -78,10 +78,13 @@ export function MyProfileModifyScreen(): React.JSX.Element {
 
   return (
     <>
-      <View style={{backgroundColor: theme.palette['gray-0']}} />
+      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
       <TopBar
         headerText="프로필 편집"
         showBackButton
+        onPressBackButton={() => {
+          navigation.pop();
+        }}
         rightComponent={() => (
           <TouchableOpacity
             onPress={() => {

--- a/src/screens/my/profile/MyProfileModifyScreen.tsx
+++ b/src/screens/my/profile/MyProfileModifyScreen.tsx
@@ -82,9 +82,6 @@ export function MyProfileModifyScreen(): React.JSX.Element {
       <TopBar
         headerText="프로필 편집"
         showBackButton
-        onPressBackButton={() => {
-          navigation.pop();
-        }}
         rightComponent={() => (
           <TouchableOpacity
             onPress={() => {

--- a/src/screens/my/profile/MyProfileScreen.tsx
+++ b/src/screens/my/profile/MyProfileScreen.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 
 import styled from '@emotion/native';
 import {type NativeStackScreenProps} from '@react-navigation/native-stack';
-import {ScrollView, View} from 'react-native';
+import {SafeAreaView, ScrollView, View} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
 import {penXmlData} from '../../../assets/svg';
@@ -47,10 +47,16 @@ export function MyProfileScreen({navigation}: Props): React.JSX.Element {
   }, [navigation]);
 
   return (
-    <View style={{backgroundColor: theme.palette['gray-0']}}>
+    <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}}>
       {isSuccess ? (
         <>
-          <TopBar headerText="프로필 편집" showBackButton />
+          <TopBar
+            headerText="프로필 편집"
+            showBackButton
+            onPressBackButton={() => {
+              navigation.pop();
+            }}
+          />
 
           <ScrollView>
             <StyledProfileSection>
@@ -126,7 +132,7 @@ export function MyProfileScreen({navigation}: Props): React.JSX.Element {
       ) : (
         <View></View>
       )}
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/src/screens/my/profile/MyProfileScreen.tsx
+++ b/src/screens/my/profile/MyProfileScreen.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 
 import styled from '@emotion/native';
 import {type NativeStackScreenProps} from '@react-navigation/native-stack';
-import {SafeAreaView, ScrollView, View} from 'react-native';
+import {ScrollView, View} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
 import {penXmlData} from '../../../assets/svg';
@@ -47,16 +47,10 @@ export function MyProfileScreen({navigation}: Props): React.JSX.Element {
   }, [navigation]);
 
   return (
-    <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}}>
+    <View style={{backgroundColor: theme.palette['gray-0']}}>
       {isSuccess ? (
         <>
-          <TopBar
-            headerText="프로필 편집"
-            showBackButton
-            onPressBackButton={() => {
-              navigation.pop();
-            }}
-          />
+          <TopBar headerText="프로필 편집" showBackButton />
 
           <ScrollView>
             <StyledProfileSection>
@@ -132,7 +126,7 @@ export function MyProfileScreen({navigation}: Props): React.JSX.Element {
       ) : (
         <View></View>
       )}
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/src/screens/my/profile/MyProfileScreen.tsx
+++ b/src/screens/my/profile/MyProfileScreen.tsx
@@ -50,13 +50,7 @@ export function MyProfileScreen({navigation}: Props): React.JSX.Element {
     <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}}>
       {isSuccess ? (
         <>
-          <TopBar
-            headerText="프로필 편집"
-            showBackButton
-            onPressBackButton={() => {
-              navigation.pop();
-            }}
-          />
+          <TopBar headerText="프로필 편집" showBackButton />
 
           <ScrollView>
             <StyledProfileSection>

--- a/src/screens/my/setting/SettingConnectedAccount.tsx
+++ b/src/screens/my/setting/SettingConnectedAccount.tsx
@@ -22,13 +22,7 @@ export const SettingConnectedAccount = (): React.JSX.Element => {
   return (
     <>
       <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
-      <TopBar
-        showBackButton
-        onPressBackButton={() => {
-          navigation.pop();
-        }}
-        headerText="연결된 계정"
-      />
+      <TopBar showBackButton headerText="연결된 계정" />
 
       <StyledContainer>
         {myProfileDetail != null && (

--- a/src/screens/my/setting/SettingConnectedAccount.tsx
+++ b/src/screens/my/setting/SettingConnectedAccount.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from '@emotion/native';
 import {useNavigation} from '@react-navigation/native';
 import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {SafeAreaView} from 'react-native';
+import {View} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
 import {Line} from '../../../components/Line';
@@ -21,14 +21,8 @@ export const SettingConnectedAccount = (): React.JSX.Element => {
 
   return (
     <>
-      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
-      <TopBar
-        showBackButton
-        onPressBackButton={() => {
-          navigation.pop();
-        }}
-        headerText="연결된 계정"
-      />
+      <View style={{backgroundColor: theme.palette['gray-0']}} />
+      <TopBar showBackButton headerText="연결된 계정" />
 
       <StyledContainer>
         {myProfileDetail != null && (

--- a/src/screens/my/setting/SettingConnectedAccount.tsx
+++ b/src/screens/my/setting/SettingConnectedAccount.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from '@emotion/native';
 import {useNavigation} from '@react-navigation/native';
 import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {View} from 'react-native';
+import {SafeAreaView} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
 import {Line} from '../../../components/Line';
@@ -21,8 +21,14 @@ export const SettingConnectedAccount = (): React.JSX.Element => {
 
   return (
     <>
-      <View style={{backgroundColor: theme.palette['gray-0']}} />
-      <TopBar showBackButton headerText="연결된 계정" />
+      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
+      <TopBar
+        showBackButton
+        onPressBackButton={() => {
+          navigation.pop();
+        }}
+        headerText="연결된 계정"
+      />
 
       <StyledContainer>
         {myProfileDetail != null && (

--- a/src/screens/my/setting/SettingResignationScreen.tsx
+++ b/src/screens/my/setting/SettingResignationScreen.tsx
@@ -1,9 +1,7 @@
 import React, {useMemo, useState} from 'react';
 
 import styled from '@emotion/native';
-import {useNavigation} from '@react-navigation/native';
-import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {SafeAreaView} from 'react-native';
+import {View} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
 import {Button} from '../../../components/Button';
@@ -12,7 +10,6 @@ import {LinedCheckBox} from '../../../components/CheckBox/LinedCheckBox';
 import {Gap} from '../../../components/Gap';
 import {TopBar} from '../../../components/TopBar';
 import {ResignationAchievementCard} from '../../../features/my/components';
-import {type MyStackParamList} from '../../../navigators/MyNavigator';
 
 interface ITerms {
   personalInfo: boolean;
@@ -22,9 +19,6 @@ interface ITerms {
 type TTerm = keyof ITerms;
 
 export function SettingResignationScreen(): React.JSX.Element {
-  const navigation =
-    useNavigation<NativeStackNavigationProp<MyStackParamList>>();
-
   const [terms, setTerms] = useState<ITerms>({
     personalInfo: false,
     id: false,
@@ -50,14 +44,8 @@ export function SettingResignationScreen(): React.JSX.Element {
 
   return (
     <>
-      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
-      <TopBar
-        headerText="회원탈퇴"
-        showBackButton
-        onPressBackButton={() => {
-          navigation.pop();
-        }}
-      />
+      <View style={{backgroundColor: theme.palette['gray-0']}} />
+      <TopBar headerText="회원탈퇴" showBackButton />
       <StyledContainer>
         <StyledContentsSection>
           <Gap size={'10px'} />

--- a/src/screens/my/setting/SettingResignationScreen.tsx
+++ b/src/screens/my/setting/SettingResignationScreen.tsx
@@ -1,7 +1,9 @@
 import React, {useMemo, useState} from 'react';
 
 import styled from '@emotion/native';
-import {View} from 'react-native';
+import {useNavigation} from '@react-navigation/native';
+import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {SafeAreaView} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
 import {Button} from '../../../components/Button';
@@ -10,6 +12,7 @@ import {LinedCheckBox} from '../../../components/CheckBox/LinedCheckBox';
 import {Gap} from '../../../components/Gap';
 import {TopBar} from '../../../components/TopBar';
 import {ResignationAchievementCard} from '../../../features/my/components';
+import {type MyStackParamList} from '../../../navigators/MyNavigator';
 
 interface ITerms {
   personalInfo: boolean;
@@ -19,6 +22,9 @@ interface ITerms {
 type TTerm = keyof ITerms;
 
 export function SettingResignationScreen(): React.JSX.Element {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<MyStackParamList>>();
+
   const [terms, setTerms] = useState<ITerms>({
     personalInfo: false,
     id: false,
@@ -44,8 +50,14 @@ export function SettingResignationScreen(): React.JSX.Element {
 
   return (
     <>
-      <View style={{backgroundColor: theme.palette['gray-0']}} />
-      <TopBar headerText="회원탈퇴" showBackButton />
+      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
+      <TopBar
+        headerText="회원탈퇴"
+        showBackButton
+        onPressBackButton={() => {
+          navigation.pop();
+        }}
+      />
       <StyledContainer>
         <StyledContentsSection>
           <Gap size={'10px'} />

--- a/src/screens/my/setting/SettingResignationScreen.tsx
+++ b/src/screens/my/setting/SettingResignationScreen.tsx
@@ -1,8 +1,6 @@
 import React, {useMemo, useState} from 'react';
 
 import styled from '@emotion/native';
-import {useNavigation} from '@react-navigation/native';
-import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {SafeAreaView} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
@@ -12,7 +10,6 @@ import {LinedCheckBox} from '../../../components/CheckBox/LinedCheckBox';
 import {Gap} from '../../../components/Gap';
 import {TopBar} from '../../../components/TopBar';
 import {ResignationAchievementCard} from '../../../features/my/components';
-import {type MyStackParamList} from '../../../navigators/MyNavigator';
 
 interface ITerms {
   personalInfo: boolean;
@@ -22,9 +19,6 @@ interface ITerms {
 type TTerm = keyof ITerms;
 
 export function SettingResignationScreen(): React.JSX.Element {
-  const navigation =
-    useNavigation<NativeStackNavigationProp<MyStackParamList>>();
-
   const [terms, setTerms] = useState<ITerms>({
     personalInfo: false,
     id: false,
@@ -51,13 +45,7 @@ export function SettingResignationScreen(): React.JSX.Element {
   return (
     <>
       <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
-      <TopBar
-        headerText="회원탈퇴"
-        showBackButton
-        onPressBackButton={() => {
-          navigation.pop();
-        }}
-      />
+      <TopBar headerText="회원탈퇴" showBackButton />
       <StyledContainer>
         <StyledContentsSection>
           <Gap size={'10px'} />

--- a/src/screens/my/setting/SettingScreen.tsx
+++ b/src/screens/my/setting/SettingScreen.tsx
@@ -3,7 +3,7 @@ import React, {useMemo, useState} from 'react';
 import styled from '@emotion/native';
 import {useNavigation} from '@react-navigation/native';
 import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {SafeAreaView} from 'react-native';
+import {View} from 'react-native';
 import email from 'react-native-email';
 
 import {theme} from '../../../assets/styles/theme';
@@ -73,14 +73,8 @@ export function SettingScreen(): React.JSX.Element {
 
   return (
     <>
-      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
-      <TopBar
-        headerText="설정"
-        showBackButton
-        onPressBackButton={() => {
-          myNavigation.pop();
-        }}
-      />
+      <View style={{backgroundColor: theme.palette['gray-0']}} />
+      <TopBar headerText="설정" showBackButton />
       <StyledContainer>
         <StyledSettingListItemPressable
           onPress={() => {

--- a/src/screens/my/setting/SettingScreen.tsx
+++ b/src/screens/my/setting/SettingScreen.tsx
@@ -74,13 +74,7 @@ export function SettingScreen(): React.JSX.Element {
   return (
     <>
       <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
-      <TopBar
-        headerText="설정"
-        showBackButton
-        onPressBackButton={() => {
-          myNavigation.pop();
-        }}
-      />
+      <TopBar headerText="설정" showBackButton />
       <StyledContainer>
         <StyledSettingListItemPressable
           onPress={() => {

--- a/src/screens/my/setting/SettingScreen.tsx
+++ b/src/screens/my/setting/SettingScreen.tsx
@@ -3,7 +3,7 @@ import React, {useMemo, useState} from 'react';
 import styled from '@emotion/native';
 import {useNavigation} from '@react-navigation/native';
 import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {View} from 'react-native';
+import {SafeAreaView} from 'react-native';
 import email from 'react-native-email';
 
 import {theme} from '../../../assets/styles/theme';
@@ -73,8 +73,14 @@ export function SettingScreen(): React.JSX.Element {
 
   return (
     <>
-      <View style={{backgroundColor: theme.palette['gray-0']}} />
-      <TopBar headerText="설정" showBackButton />
+      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
+      <TopBar
+        headerText="설정"
+        showBackButton
+        onPressBackButton={() => {
+          myNavigation.pop();
+        }}
+      />
       <StyledContainer>
         <StyledSettingListItemPressable
           onPress={() => {


### PR DESCRIPTION
## branch

- `main` <- `feature/topbar2`

## Summary

-  `TopBar` 컴포넌트 내에 뒤로가기 버튼 클릭 시, `navigation.goBack()`을 자체적으로 수행하도록 수정합니다.
- 불꽃 레벨 설명 스크린에서 해당 `TopBar` 컴포넌트를 사용하도록 수정합니다.

## Task
- [x] `TopBar` 컴포넌트 수정
- [x] `TeamWorkRateInfo(불꽃 레벨 설명 스크린)` 컴포넌트 수정


## Issue Number

- Close #Issue-Number
