### PR TITLE
✨ feat: 마이페이지 - 나의 불꽃 히스토리 조회 기능 

### DIFF
--- a/src/features/my/components/overview/TeamworkRateSection/TeamworkRateFlameGroup.tsx
+++ b/src/features/my/components/overview/TeamworkRateSection/TeamworkRateFlameGroup.tsx
@@ -7,24 +7,41 @@ import {fireScoreXmlData} from '../../../../../assets/svg';
 import {Icon} from '../../../../../components/Icon';
 import {getFlameData} from '../../../const';
 
+const sizes = {
+  sm: {
+    iconSize: 23,
+    gap: 2,
+  },
+  md: {
+    iconSize: 48,
+    gap: 8,
+  },
+} as const;
+
 interface TeamworkRateFlameGroupProps {
   rate: number;
+  size?: keyof typeof sizes;
+  color?: string;
 }
 
 export const TeamworkRateFlameGroup = ({
   rate,
+  size = 'md',
+  color: customColor,
 }: TeamworkRateFlameGroupProps): React.JSX.Element => {
   const {color} = getFlameData(rate);
 
   return (
-    <StyledHorizontal style={{gap: 8}}>
+    <StyledHorizontal style={{gap: sizes[size].gap}}>
       {Array.from({length: 5}, (_, index) => (
         <Icon
           key={index}
           svgXml={fireScoreXmlData}
-          height={48}
-          width={48}
-          color={index < rate ? color : theme.palette['gray-400']}
+          height={sizes[size].iconSize}
+          width={sizes[size].iconSize}
+          color={
+            index < rate ? customColor ?? color : theme.palette['gray-400']
+          }
         />
       ))}
     </StyledHorizontal>

--- a/src/features/my/components/overview/TeamworkRateSection/TeamworkRateSection.tsx
+++ b/src/features/my/components/overview/TeamworkRateSection/TeamworkRateSection.tsx
@@ -27,7 +27,10 @@ export const TeamworkRateSection = (): React.JSX.Element => {
       <StyledHorizontal style={{justifyContent: 'space-between'}}>
         <Text text="나의 불꽃 레벨" type="head4" color="gray-950" />
 
-        <TouchableOpacity>
+        <TouchableOpacity
+          onPress={() => {
+            navigation.navigate('TeamworkRateHistory');
+          }}>
           <Text text="불꽃 히스토리" type="body3" color="gray-600" />
         </TouchableOpacity>
       </StyledHorizontal>
@@ -37,7 +40,7 @@ export const TeamworkRateSection = (): React.JSX.Element => {
       <StyledCard>
         <StyledIconWrapper
           onPress={() => {
-            navigation.navigate('TeamWorkRateInfo');
+            navigation.navigate('TeamworkRateInfo');
           }}>
           <Icon
             svgXml={questionXmlData}

--- a/src/features/my/components/teamworkRate/TeamworkRateHistoryCard.tsx
+++ b/src/features/my/components/teamworkRate/TeamworkRateHistoryCard.tsx
@@ -88,6 +88,12 @@ export const TeamworkRateHistoryCard = ({
     LOSE: 'sub-400',
   };
 
+  const flameColor: Record<TWinStatus, TPalette> = {
+    DRAW: 'gray-600',
+    WIN: 'main-400',
+    LOSE: 'error-light',
+  };
+
   const {title, descriptionComponent: Description} =
     generateMatchText(teamworkRateHistory);
 
@@ -107,11 +113,20 @@ export const TeamworkRateHistoryCard = ({
 
       <Description />
 
-      <StyledHorizontal style={{justifyContent: 'flex-end'}}>
+      <StyledHorizontal style={{justifyContent: 'flex-end', gap: 10}}>
+        <Text
+          type="body1"
+          fontWeight="700"
+          text={`${teamworkRateHistory.teamworkRate}불꽃 ${
+            // TODO(@minimalKim): LOSE일 경우 차감 맞는지 백엔드 데이터 확인 필요
+            teamworkRateHistory.winStatus === 'LOSE' ? '차감' : '획득'
+          }`}
+          color={flameColor[teamworkRateHistory.winStatus]}
+        />
         <TeamworkRateFlameGroup
           size="sm"
           rate={teamworkRateHistory.teamworkRate}
-          color={theme.palette['main-400']}
+          color={theme.palette[flameColor[teamworkRateHistory.winStatus]]}
         />
       </StyledHorizontal>
     </StyledTeamworkRateHistoryCard>

--- a/src/features/my/components/teamworkRate/TeamworkRateHistoryCard.tsx
+++ b/src/features/my/components/teamworkRate/TeamworkRateHistoryCard.tsx
@@ -1,0 +1,131 @@
+import React, {useCallback} from 'react';
+
+import styled from '@emotion/native';
+
+import {type TPalette} from '../../../../assets/styles/emotion';
+import {theme} from '../../../../assets/styles/theme';
+import {Text} from '../../../../components/Text';
+import {type TPeriod, type TWinStatus} from '../../../match/types';
+import {type ITeamworkRateHistory} from '../../types';
+import {TeamworkRateFlameGroup} from '../overview/TeamworkRateSection/TeamworkRateFlameGroup';
+
+interface ITeamworkRateHistoryCardProps {
+  teamworkRateHistory: ITeamworkRateHistory;
+}
+
+export const TeamworkRateHistoryCard = ({
+  teamworkRateHistory,
+}: ITeamworkRateHistoryCardProps): React.JSX.Element => {
+  const generateMatchText = useCallback(
+    (
+      matchInfo: ITeamworkRateHistory,
+    ): {
+      title: string;
+      descriptionComponent: () => React.JSX.Element;
+    } => {
+      const {fieldType, myFieldName, opponentName, period} = matchInfo;
+      const weekLabels: Record<TPeriod, string> = {
+        ONE_WEEK: '한 주',
+        TWO_WEEKS: '두 주',
+        THREE_WEEKS: '세 주',
+      };
+
+      switch (fieldType) {
+        case 'TEAM_BATTLE':
+          return {
+            title: '팀매칭',
+            descriptionComponent: () => (
+              <StyledHorizontal style={{gap: 8, height: 48}}>
+                <Text text={myFieldName} fontWeight="700" color="gray-700" />
+                <Text text="팀에서" color="gray-700" />
+                <Text text={opponentName} fontWeight="700" color="gray-700" />
+                <Text text="팀과" color="gray-700" />
+                <Text text="팀 매칭!" fontWeight="700" color="gray-700" />
+              </StyledHorizontal>
+            ),
+          };
+        case 'DUEL':
+          return {
+            title: '1:1 매칭',
+            descriptionComponent: () => (
+              <StyledHorizontal style={{gap: 8, height: 48}}>
+                <Text text={opponentName} fontWeight="700" color="gray-700" />
+                <Text text="님과" color="gray-700" />
+                <Text text="1:1 매칭!" fontWeight="700" color="gray-700" />
+              </StyledHorizontal>
+            ),
+          };
+
+        case 'TEAM':
+          return {
+            title: '매칭없는 팀',
+            descriptionComponent: () => (
+              <StyledHorizontal style={{gap: 8, height: 48}}>
+                <Text text={myFieldName} fontWeight="700" color="gray-700" />
+                <Text text="팀에서" color="gray-700" />
+                <Text
+                  text={`${weekLabels[period]}동안 활동`}
+                  fontWeight="700"
+                  color="gray-700"
+                />
+              </StyledHorizontal>
+            ),
+          };
+        default:
+          return {title: '', descriptionComponent: () => <></>};
+      }
+    },
+    [],
+  );
+
+  const capitalizeFirstLetter = (str: string): string => {
+    return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+  };
+
+  const statusColor: Record<TWinStatus, TPalette> = {
+    DRAW: 'gray-600',
+    WIN: 'main-400',
+    LOSE: 'sub-400',
+  };
+
+  const {title, descriptionComponent: Description} =
+    generateMatchText(teamworkRateHistory);
+
+  return (
+    <StyledTeamworkRateHistoryCard>
+      <StyledHorizontal style={{justifyContent: 'space-between'}}>
+        <Text type="body1" text={title} fontWeight="700" color="gray-700" />
+        {teamworkRateHistory.fieldType !== 'TEAM' && (
+          <Text
+            type="body1"
+            text={capitalizeFirstLetter(teamworkRateHistory.winStatus)}
+            fontWeight="700"
+            color={statusColor[teamworkRateHistory.winStatus]}
+          />
+        )}
+      </StyledHorizontal>
+
+      <Description />
+
+      <StyledHorizontal style={{justifyContent: 'flex-end'}}>
+        <TeamworkRateFlameGroup
+          size="sm"
+          rate={teamworkRateHistory.teamworkRate}
+          color={theme.palette['main-400']}
+        />
+      </StyledHorizontal>
+    </StyledTeamworkRateHistoryCard>
+  );
+};
+
+const StyledTeamworkRateHistoryCard = styled.View`
+  background-color: ${({theme}) => theme.palette['gray-50']};
+  padding: 18px 20px;
+  border-radius: ${({theme}) => theme.borderRadius.lg};
+`;
+
+const StyledHorizontal = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;

--- a/src/features/my/components/teamworkRate/index.ts
+++ b/src/features/my/components/teamworkRate/index.ts
@@ -1,0 +1,1 @@
+export * from './TeamworkRateHistoryCard';

--- a/src/features/my/hooks/teamworkRate/index.ts
+++ b/src/features/my/hooks/teamworkRate/index.ts
@@ -1,0 +1,1 @@
+export * from './useGetTeamworkRateHistory';

--- a/src/features/my/hooks/teamworkRate/keys.ts
+++ b/src/features/my/hooks/teamworkRate/keys.ts
@@ -1,5 +1,8 @@
+import {type IGetTeamworkRateHistoryParams} from './useGetTeamworkRateHistory';
+
 export const KEYS = {
   all: ['teamwork-rate'] as const,
 
-  teamworkRateHistory: () => [...KEYS.all, 'history'] as const,
+  teamworkRateHistory: (params: IGetTeamworkRateHistoryParams) =>
+    [...KEYS.all, 'history', {...params}] as const,
 };

--- a/src/features/my/hooks/teamworkRate/keys.ts
+++ b/src/features/my/hooks/teamworkRate/keys.ts
@@ -1,0 +1,5 @@
+export const KEYS = {
+  all: ['teamwork-rate'] as const,
+
+  teamworkRateHistory: () => [...KEYS.all, 'history'] as const,
+};

--- a/src/features/my/hooks/teamworkRate/useGetTeamworkRateHistory.ts
+++ b/src/features/my/hooks/teamworkRate/useGetTeamworkRateHistory.ts
@@ -34,6 +34,7 @@ export const useGetTeamworkRateHistory = (
     queryKey: KEYS.teamworkRateHistory(),
     queryFn: async ({pageParam = 1}) =>
       await fetcher({...params, page: pageParam}),
-    getNextPageParam: lastPage => lastPage.isLastPage,
+    getNextPageParam: lastPage =>
+      lastPage.isLastPage ? null : lastPage.currentPage + 1,
     cacheTime: 0,
   });

--- a/src/features/my/hooks/teamworkRate/useGetTeamworkRateHistory.ts
+++ b/src/features/my/hooks/teamworkRate/useGetTeamworkRateHistory.ts
@@ -9,7 +9,7 @@ import {type TFieldType} from '../../../match/types';
 import {type ITeamworkRateHistory} from '../../types';
 
 export interface IGetTeamworkRateHistoryParams {
-  fieldType: TFieldType;
+  fieldType?: TFieldType;
   page: number;
   size: number;
 }
@@ -31,7 +31,7 @@ export const useGetTeamworkRateHistory = (
   params: IGetTeamworkRateHistoryParams,
 ): UseInfiniteQueryResult<TGetNotificationUserResponse, Error> =>
   useInfiniteQuery({
-    queryKey: KEYS.teamworkRateHistory(),
+    queryKey: KEYS.teamworkRateHistory(params),
     queryFn: async ({pageParam = 1}) =>
       await fetcher({...params, page: pageParam}),
     getNextPageParam: lastPage =>

--- a/src/features/my/hooks/teamworkRate/useGetTeamworkRateHistory.ts
+++ b/src/features/my/hooks/teamworkRate/useGetTeamworkRateHistory.ts
@@ -1,0 +1,39 @@
+import {
+  useInfiniteQuery,
+  type UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {axios} from '../../../../lib/axios';
+import {type TFieldType} from '../../../match/types';
+import {type ITeamworkRateHistory} from '../../types';
+
+export interface IGetTeamworkRateHistoryParams {
+  fieldType: TFieldType;
+  page: number;
+  size: number;
+}
+
+export interface TGetNotificationUserResponse {
+  currentPage: number;
+  currentPageSize: number;
+  isFirstPage: boolean;
+  isLastPage: boolean;
+  teamworkRateHistoryDtos: ITeamworkRateHistory[];
+}
+
+const fetcher = async (
+  params: IGetTeamworkRateHistoryParams,
+): Promise<TGetNotificationUserResponse> =>
+  await axios.get('/teamwork-rate/history', {params}).then(({data}) => data);
+
+export const useGetTeamworkRateHistory = (
+  params: IGetTeamworkRateHistoryParams,
+): UseInfiniteQueryResult<TGetNotificationUserResponse, Error> =>
+  useInfiniteQuery({
+    queryKey: KEYS.teamworkRateHistory(),
+    queryFn: async ({pageParam = 1}) =>
+      await fetcher({...params, page: pageParam}),
+    getNextPageParam: lastPage => lastPage.isLastPage,
+    cacheTime: 0,
+  });

--- a/src/features/my/types/index.ts
+++ b/src/features/my/types/index.ts
@@ -1,1 +1,2 @@
 export * from './profile';
+export * from './teamworkRate';

--- a/src/features/my/types/teamworkRate.ts
+++ b/src/features/my/types/teamworkRate.ts
@@ -1,0 +1,15 @@
+import {
+  type TFieldType,
+  type TPeriod,
+  type TWinStatus,
+} from '../../match/types';
+
+export interface ITeamworkRateHistory {
+  endDate: string;
+  fieldType: TFieldType;
+  myFieldName: string;
+  opponentName: string;
+  period: TPeriod;
+  teamworkRate: number;
+  winStatus: TWinStatus;
+}

--- a/src/navigators/MyNavigator.tsx
+++ b/src/navigators/MyNavigator.tsx
@@ -6,7 +6,8 @@ import {
   MyProfileModifyScreen,
   MyProfileScreen,
   MyScreen,
-  TeamWorkRateInfo,
+  TeamworkRateInfo,
+  TeamworkRateHistory,
   type TMyProfileModifyScreenSectionType,
 } from '../screens/my';
 import {
@@ -25,7 +26,8 @@ export type MyStackParamList = {
   SettingNotification: undefined;
   SettingConnectedAccount: undefined;
   SettingResignation: undefined;
-  TeamWorkRateInfo: undefined;
+  TeamworkRateInfo: undefined;
+  TeamworkRateHistory: undefined;
 };
 
 const Stack = createNativeStackNavigator<MyStackParamList>();
@@ -81,8 +83,15 @@ export function MyNavigator(): React.JSX.Element {
         }}
       />
       <Stack.Screen
-        name="TeamWorkRateInfo"
-        component={TeamWorkRateInfo}
+        name="TeamworkRateInfo"
+        component={TeamworkRateInfo}
+        options={{
+          headerShown: false,
+        }}
+      />
+      <Stack.Screen
+        name="TeamworkRateHistory"
+        component={TeamworkRateHistory}
         options={{
           headerShown: false,
         }}

--- a/src/screens/my/index.ts
+++ b/src/screens/my/index.ts
@@ -1,3 +1,3 @@
 export * from './MyScreen';
 export * from './profile';
-export * from './TeamWorkRateInfo';
+export * from './teamworkRate';

--- a/src/screens/my/teamworkRate/TeamworkRateHistory.tsx
+++ b/src/screens/my/teamworkRate/TeamworkRateHistory.tsx
@@ -1,55 +1,69 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 
 import styled from '@emotion/native';
-import {FlatList, SafeAreaView, TouchableOpacity} from 'react-native';
+import {type NativeStackScreenProps} from '@react-navigation/native-stack';
+import {FlatList, SafeAreaView, TouchableOpacity, View} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
 import {Gap} from '../../../components/Gap';
 import {Text} from '../../../components/Text';
 import {TopBar} from '../../../components/TopBar';
 import {TeamworkRateHistoryCard} from '../../../features/my/components/teamworkRate';
+import {useGetTeamworkRateHistory} from '../../../features/my/hooks/teamworkRate';
 import {type ITeamworkRateHistory} from '../../../features/my/types';
 import {dayjs} from '../../../lib/dayjs';
+import {type MyStackParamList} from '../../../navigators/MyNavigator';
 
-export const TeamworkRateHistory = (): React.JSX.Element => {
-  const dummy: ITeamworkRateHistory[] = [
-    {
-      endDate: '2023-12-15',
-      fieldType: 'DUEL',
-      myFieldName: 'string',
-      opponentName: '김마르',
-      period: 'ONE_WEEK',
-      teamworkRate: 4,
-      winStatus: 'WIN',
-    },
-    {
-      endDate: '2023-12-15',
-      fieldType: 'TEAM_BATTLE',
-      myFieldName: '작심삼년',
-      opponentName: '가보자고',
-      period: 'ONE_WEEK',
-      teamworkRate: 3,
-      winStatus: 'DRAW',
-    },
-    {
-      endDate: '2023-12-14',
-      fieldType: 'TEAM_BATTLE',
-      myFieldName: '작심삼년',
-      opponentName: '가보자고',
-      period: 'ONE_WEEK',
-      teamworkRate: 2,
-      winStatus: 'LOSE',
-    },
-    {
-      endDate: '2023-12-13',
-      fieldType: 'TEAM',
-      myFieldName: '작심삼년',
-      opponentName: '가보자고',
-      period: 'ONE_WEEK',
-      teamworkRate: 1,
-      winStatus: 'DRAW',
-    },
-  ];
+type Props = NativeStackScreenProps<MyStackParamList, 'TeamworkRateHistory'>;
+
+export const TeamworkRateHistory = ({navigation}: Props): React.JSX.Element => {
+  // const dummy: ITeamworkRateHistory[] = [
+  //   {
+  //     endDate: '2023-12-15',
+  //     fieldType: 'DUEL',
+  //     myFieldName: 'string',
+  //     opponentName: '김마르',
+  //     period: 'ONE_WEEK',
+  //     teamworkRate: 4,
+  //     winStatus: 'WIN',
+  //   },
+  //   {
+  //     endDate: '2023-12-15',
+  //     fieldType: 'TEAM_BATTLE',
+  //     myFieldName: '작심삼년',
+  //     opponentName: '가보자고',
+  //     period: 'ONE_WEEK',
+  //     teamworkRate: 3,
+  //     winStatus: 'DRAW',
+  //   },
+  //   {
+  //     endDate: '2023-12-14',
+  //     fieldType: 'TEAM_BATTLE',
+  //     myFieldName: '작심삼년',
+  //     opponentName: '가보자고',
+  //     period: 'ONE_WEEK',
+  //     teamworkRate: 2,
+  //     winStatus: 'LOSE',
+  //   },
+  //   {
+  //     endDate: '2023-12-13',
+  //     fieldType: 'TEAM',
+  //     myFieldName: '작심삼년',
+  //     opponentName: '가보자고',
+  //     period: 'ONE_WEEK',
+  //     teamworkRate: 1,
+  //     winStatus: 'DRAW',
+  //   },
+  // ];
+
+  const {data} = useGetTeamworkRateHistory({
+    fieldType: 'DUEL',
+    page: 0,
+    size: 10,
+  });
+
+  const histories =
+    data?.pages.flatMap(page => page.teamworkRateHistoryDtos) ?? [];
 
   const renderItem = ({
     item,
@@ -59,7 +73,7 @@ export const TeamworkRateHistory = (): React.JSX.Element => {
     index: number;
   }): React.JSX.Element => {
     const isDateLabelVisible =
-      index === 0 || item.endDate !== dummy[index - 1].endDate;
+      index === 0 || item.endDate !== histories[index - 1].endDate;
     return (
       <>
         {isDateLabelVisible && (
@@ -77,6 +91,31 @@ export const TeamworkRateHistory = (): React.JSX.Element => {
       </>
     );
   };
+
+  // TODO: 공통 hook 으로 분리
+  useEffect(() => {
+    navigation.getParent()?.setOptions({
+      tabBarStyle: {
+        display: 'none',
+      },
+      tabBarVisible: false,
+    });
+    return () =>
+      navigation.getParent()?.setOptions({
+        tabBarStyle: {
+          height: 80,
+          paddingTop: 10,
+          paddingBottom: 20,
+          paddingHorizontal: 16,
+          borderTopLeftRadius: 24,
+          borderTopRightRadius: 24,
+          borderWidth: 1,
+          borderColor: theme.palette['gray-50'],
+          position: 'absolute',
+        },
+        tabBarVisible: true,
+      });
+  }, [navigation]);
 
   return (
     <>
@@ -100,13 +139,40 @@ export const TeamworkRateHistory = (): React.JSX.Element => {
 
         <StyledScrollView>
           <StyledCardContainer>
-            <FlatList
-              data={dummy}
-              renderItem={renderItem}
-              // TODO(@minimalKim): history item id 프로퍼티 백엔드에 추가 요청
-              keyExtractor={(_, index) => index.toString()}
-              contentContainerStyle={{padding: 20}}
-            />
+            {histories.length > 0 ? (
+              <FlatList
+                data={histories}
+                renderItem={renderItem}
+                // TODO(@minimalKim): history item id 프로퍼티 백엔드에 추가 요청
+                keyExtractor={(_, index) => index.toString()}
+                contentContainerStyle={{padding: 20}}
+                ListFooterComponent={
+                  <View style={{display: 'flex', alignItems: 'center'}}>
+                    <StyledMoreButton
+                      onPress={() => {
+                        // TODO(@minimalKim): 추가 로드
+                      }}>
+                      <Text
+                        text="더보기"
+                        type="body3"
+                        fontWeight="600"
+                        color="gray-600"
+                      />
+                    </StyledMoreButton>
+                    <View style={{height: 150}} />
+                  </View>
+                }
+              />
+            ) : (
+              <StyledNoContentsWrapper>
+                <Text
+                  type="body2"
+                  color="gray-400"
+                  fontWeight="600"
+                  text="내역이 존재하지 않습니다."
+                />
+              </StyledNoContentsWrapper>
+            )}
           </StyledCardContainer>
         </StyledScrollView>
       </>
@@ -124,10 +190,22 @@ const StyledTabContainer = styled.View`
   background-color: ${({theme}) => theme.palette['gray-0']};
 `;
 
-const StyledScrollView = styled.ScrollView`
+const StyledScrollView = styled.View`
   background-color: ${({theme}) => theme.palette['gray-0']};
 `;
 
 const StyledCardContainer = styled.View`
   display: flex;
+`;
+
+const StyledMoreButton = styled.TouchableOpacity`
+  border-radius: 16px;
+  background-color: ${({theme}) => theme.palette['gray-100']};
+  padding: 16px 60px;
+  margin: 20px 0;
+`;
+
+const StyledNoContentsWrapper = styled.View`
+  margin: 40px auto 30px auto;
+  height: 100%;
 `;

--- a/src/screens/my/teamworkRate/TeamworkRateHistory.tsx
+++ b/src/screens/my/teamworkRate/TeamworkRateHistory.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styled from '@emotion/native';
-import {SafeAreaView, TouchableOpacity} from 'react-native';
+import {FlatList, SafeAreaView, TouchableOpacity} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
 import {Gap} from '../../../components/Gap';
@@ -51,14 +51,31 @@ export const TeamworkRateHistory = (): React.JSX.Element => {
     },
   ];
 
-  const isDateLabelVisible = (
-    currentItem: ITeamworkRateHistory,
-    previousItem?: ITeamworkRateHistory,
-  ): boolean => {
-    if (previousItem == null) {
-      return true;
-    }
-    return currentItem.endDate !== previousItem.endDate;
+  const renderItem = ({
+    item,
+    index,
+  }: {
+    item: ITeamworkRateHistory;
+    index: number;
+  }): React.JSX.Element => {
+    const isDateLabelVisible =
+      index === 0 || item.endDate !== dummy[index - 1].endDate;
+    return (
+      <>
+        {isDateLabelVisible && (
+          <>
+            <Gap size="16px" />
+            <Text
+              text={dayjs(item.endDate).format('MM월 DD일')}
+              color="gray-400"
+            />
+            <Gap size="8px" />
+          </>
+        )}
+        <TeamworkRateHistoryCard teamworkRateHistory={item} />
+        <Gap size="12px" />
+      </>
+    );
   };
 
   return (
@@ -83,24 +100,13 @@ export const TeamworkRateHistory = (): React.JSX.Element => {
 
         <StyledScrollView>
           <StyledCardContainer>
-            {dummy.map((history, idx, historyList) => (
-              <>
-                {isDateLabelVisible(history, historyList[idx - 1]) && (
-                  <>
-                    <Gap size="16px" />
-                    <Text
-                      text={dayjs(history.endDate).format('MM월 DD일')}
-                      color="gray-400"
-                    />
-                    <Gap size="8px" />
-                  </>
-                )}
-                <TeamworkRateHistoryCard
-                  key={idx}
-                  teamworkRateHistory={history}
-                />
-              </>
-            ))}
+            <FlatList
+              data={dummy}
+              renderItem={renderItem}
+              // TODO(@minimalKim): history item id 프로퍼티 백엔드에 추가 요청
+              keyExtractor={(_, index) => index.toString()}
+              contentContainerStyle={{padding: 20}}
+            />
           </StyledCardContainer>
         </StyledScrollView>
       </>
@@ -124,6 +130,4 @@ const StyledScrollView = styled.ScrollView`
 
 const StyledCardContainer = styled.View`
   display: flex;
-  gap: 12px;
-  padding: 0 20px 20px 20px;
 `;

--- a/src/screens/my/teamworkRate/TeamworkRateHistory.tsx
+++ b/src/screens/my/teamworkRate/TeamworkRateHistory.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+import {SafeAreaView, TouchableOpacity} from 'react-native';
+
+import {theme} from '../../../assets/styles/theme';
+import {Text} from '../../../components/Text';
+import {TopBar} from '../../../components/TopBar';
+
+export const TeamworkRateHistory = (): React.JSX.Element => {
+  return (
+    <>
+      <>
+        <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
+        <TopBar showBackButton headerText="불꽃 히스토리" />
+        <StyledTabContainer>
+          <TouchableOpacity>
+            <Text text="전쳬보기" type="body3" color="gray-400" />
+          </TouchableOpacity>
+          <TouchableOpacity>
+            <Text text="1:1 매칭" type="body3" color="gray-400" />
+          </TouchableOpacity>
+          <TouchableOpacity>
+            <Text text="팀 매칭" type="body3" color="gray-400" />
+          </TouchableOpacity>
+          <TouchableOpacity>
+            <Text text="매칭 없는 팀" type="body3" color="gray-400" />
+          </TouchableOpacity>
+        </StyledTabContainer>
+        <StyledScrollView></StyledScrollView>
+      </>
+    </>
+  );
+};
+
+const StyledTabContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 30px;
+  padding: 16px;
+  background-color: ${({theme}) => theme.palette['gray-0']};
+`;
+
+const StyledScrollView = styled.ScrollView`
+  background-color: ${({theme}) => theme.palette['gray-0']};
+`;

--- a/src/screens/my/teamworkRate/TeamworkRateHistory.tsx
+++ b/src/screens/my/teamworkRate/TeamworkRateHistory.tsx
@@ -4,10 +4,63 @@ import styled from '@emotion/native';
 import {SafeAreaView, TouchableOpacity} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
+import {Gap} from '../../../components/Gap';
 import {Text} from '../../../components/Text';
 import {TopBar} from '../../../components/TopBar';
+import {TeamworkRateHistoryCard} from '../../../features/my/components/teamworkRate';
+import {type ITeamworkRateHistory} from '../../../features/my/types';
+import {dayjs} from '../../../lib/dayjs';
 
 export const TeamworkRateHistory = (): React.JSX.Element => {
+  const dummy: ITeamworkRateHistory[] = [
+    {
+      endDate: '2023-12-15',
+      fieldType: 'DUEL',
+      myFieldName: 'string',
+      opponentName: '김마르',
+      period: 'ONE_WEEK',
+      teamworkRate: 4,
+      winStatus: 'WIN',
+    },
+    {
+      endDate: '2023-12-15',
+      fieldType: 'TEAM_BATTLE',
+      myFieldName: '작심삼년',
+      opponentName: '가보자고',
+      period: 'ONE_WEEK',
+      teamworkRate: 3,
+      winStatus: 'DRAW',
+    },
+    {
+      endDate: '2023-12-14',
+      fieldType: 'TEAM_BATTLE',
+      myFieldName: '작심삼년',
+      opponentName: '가보자고',
+      period: 'ONE_WEEK',
+      teamworkRate: 2,
+      winStatus: 'LOSE',
+    },
+    {
+      endDate: '2023-12-13',
+      fieldType: 'TEAM',
+      myFieldName: '작심삼년',
+      opponentName: '가보자고',
+      period: 'ONE_WEEK',
+      teamworkRate: 1,
+      winStatus: 'DRAW',
+    },
+  ];
+
+  const isDateLabelVisible = (
+    currentItem: ITeamworkRateHistory,
+    previousItem?: ITeamworkRateHistory,
+  ): boolean => {
+    if (previousItem == null) {
+      return true;
+    }
+    return currentItem.endDate !== previousItem.endDate;
+  };
+
   return (
     <>
       <>
@@ -27,7 +80,29 @@ export const TeamworkRateHistory = (): React.JSX.Element => {
             <Text text="매칭 없는 팀" type="body3" color="gray-400" />
           </TouchableOpacity>
         </StyledTabContainer>
-        <StyledScrollView></StyledScrollView>
+
+        <StyledScrollView>
+          <StyledCardContainer>
+            {dummy.map((history, idx, historyList) => (
+              <>
+                {isDateLabelVisible(history, historyList[idx - 1]) && (
+                  <>
+                    <Gap size="16px" />
+                    <Text
+                      text={dayjs(history.endDate).format('MM월 DD일')}
+                      color="gray-400"
+                    />
+                    <Gap size="8px" />
+                  </>
+                )}
+                <TeamworkRateHistoryCard
+                  key={idx}
+                  teamworkRateHistory={history}
+                />
+              </>
+            ))}
+          </StyledCardContainer>
+        </StyledScrollView>
       </>
     </>
   );
@@ -45,4 +120,10 @@ const StyledTabContainer = styled.View`
 
 const StyledScrollView = styled.ScrollView`
   background-color: ${({theme}) => theme.palette['gray-0']};
+`;
+
+const StyledCardContainer = styled.View`
+  display: flex;
+  gap: 12px;
+  padding: 0 20px 20px 20px;
 `;

--- a/src/screens/my/teamworkRate/TeamworkRateHistory.tsx
+++ b/src/screens/my/teamworkRate/TeamworkRateHistory.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import styled from '@emotion/native';
 import {type NativeStackScreenProps} from '@react-navigation/native-stack';
@@ -8,6 +8,7 @@ import {theme} from '../../../assets/styles/theme';
 import {Gap} from '../../../components/Gap';
 import {Text} from '../../../components/Text';
 import {TopBar} from '../../../components/TopBar';
+import {type TFieldType} from '../../../features/match/types';
 import {TeamworkRateHistoryCard} from '../../../features/my/components/teamworkRate';
 import {useGetTeamworkRateHistory} from '../../../features/my/hooks/teamworkRate';
 import {type ITeamworkRateHistory} from '../../../features/my/types';
@@ -56,8 +57,12 @@ export const TeamworkRateHistory = ({navigation}: Props): React.JSX.Element => {
   //   },
   // ];
 
-  const {data} = useGetTeamworkRateHistory({
-    fieldType: 'DUEL',
+  const [selectedFieldType, setSelectedFieldType] = useState<
+    'ALL' | TFieldType
+  >('ALL');
+
+  const {data, hasNextPage, fetchNextPage} = useGetTeamworkRateHistory({
+    fieldType: selectedFieldType === 'ALL' ? undefined : selectedFieldType,
     page: 0,
     size: 10,
   });
@@ -123,17 +128,47 @@ export const TeamworkRateHistory = ({navigation}: Props): React.JSX.Element => {
         <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
         <TopBar showBackButton headerText="불꽃 히스토리" />
         <StyledTabContainer>
-          <TouchableOpacity>
-            <Text text="전쳬보기" type="body3" color="gray-400" />
+          <TouchableOpacity
+            onPress={() => {
+              setSelectedFieldType('ALL');
+            }}>
+            <Text
+              text="전체보기"
+              type="body3"
+              color={selectedFieldType === 'ALL' ? 'gray-600' : 'gray-400'}
+            />
           </TouchableOpacity>
-          <TouchableOpacity>
-            <Text text="1:1 매칭" type="body3" color="gray-400" />
+          <TouchableOpacity
+            onPress={() => {
+              setSelectedFieldType('DUEL');
+            }}>
+            <Text
+              text="1:1 매칭"
+              type="body3"
+              color={selectedFieldType === 'DUEL' ? 'gray-600' : 'gray-400'}
+            />
           </TouchableOpacity>
-          <TouchableOpacity>
-            <Text text="팀 매칭" type="body3" color="gray-400" />
+          <TouchableOpacity
+            onPress={() => {
+              setSelectedFieldType('TEAM_BATTLE');
+            }}>
+            <Text
+              text="팀 매칭"
+              type="body3"
+              color={
+                selectedFieldType === 'TEAM_BATTLE' ? 'gray-600' : 'gray-400'
+              }
+            />
           </TouchableOpacity>
-          <TouchableOpacity>
-            <Text text="매칭 없는 팀" type="body3" color="gray-400" />
+          <TouchableOpacity
+            onPress={() => {
+              setSelectedFieldType('TEAM');
+            }}>
+            <Text
+              text="매칭 없는 팀"
+              type="body3"
+              color={selectedFieldType === 'TEAM' ? 'gray-600' : 'gray-400'}
+            />
           </TouchableOpacity>
         </StyledTabContainer>
 
@@ -148,17 +183,19 @@ export const TeamworkRateHistory = ({navigation}: Props): React.JSX.Element => {
                 contentContainerStyle={{padding: 20}}
                 ListFooterComponent={
                   <View style={{display: 'flex', alignItems: 'center'}}>
-                    <StyledMoreButton
-                      onPress={() => {
-                        // TODO(@minimalKim): 추가 로드
-                      }}>
-                      <Text
-                        text="더보기"
-                        type="body3"
-                        fontWeight="600"
-                        color="gray-600"
-                      />
-                    </StyledMoreButton>
+                    {(hasNextPage ?? false) && (
+                      <StyledMoreButton
+                        onPress={() => {
+                          void fetchNextPage();
+                        }}>
+                        <Text
+                          text="더보기"
+                          type="body3"
+                          fontWeight="600"
+                          color="gray-600"
+                        />
+                      </StyledMoreButton>
+                    )}
                     <View style={{height: 150}} />
                   </View>
                 }

--- a/src/screens/my/teamworkRate/TeamworkRateInfo.tsx
+++ b/src/screens/my/teamworkRate/TeamworkRateInfo.tsx
@@ -3,15 +3,15 @@ import React from 'react';
 import styled from '@emotion/native';
 import {SafeAreaView} from 'react-native';
 
-import {theme} from '../../assets/styles/theme';
-import {fireScoreXmlData} from '../../assets/svg';
-import {Gap} from '../../components/Gap';
-import {Icon} from '../../components/Icon';
-import {Text} from '../../components/Text';
-import {TopBar} from '../../components/TopBar';
-import {FLAMES} from '../../features/my/const';
+import {theme} from '../../../assets/styles/theme';
+import {fireScoreXmlData} from '../../../assets/svg';
+import {Gap} from '../../../components/Gap';
+import {Icon} from '../../../components/Icon';
+import {Text} from '../../../components/Text';
+import {TopBar} from '../../../components/TopBar';
+import {FLAMES} from '../../../features/my/const';
 
-export const TeamWorkRateInfo = (): React.JSX.Element => {
+export const TeamworkRateInfo = (): React.JSX.Element => {
   return (
     <>
       <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />

--- a/src/screens/my/teamworkRate/index.ts
+++ b/src/screens/my/teamworkRate/index.ts
@@ -1,0 +1,2 @@
+export * from './TeamworkRateHistory';
+export * from './TeamworkRateInfo';


### PR DESCRIPTION
## branch

- `main` <- `feature/my_teamwork_rate_history`

## Summary

- 나의 불꽃 히스토리 조회 기능을 추가합니다.

|나의 불꽃 히스토리 스크린 - 데이터가 없을 경우 | 나의 불꽃 히스토리 스크린 - 데이터가 있을 경우|
|:---:|:---:|
|![image](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/32cd1eae-cd47-414d-8384-613b37d6b87b)|![image](https://github.com/dnd-side-project/dnd-9th-9-frontend/assets/80511900/e2abd77f-64ab-46dc-9321-8777320e162b)|

## Task

- [x] 나의 불꽃 히스토리(TeamworkRateHistory)  스크린추가
- [x] 나의 불꽃 히스토리 조회를 위한 useGetTeamworkRateHistory query 연동

## ETC

- 유의 사항, 참고할 내용을 추가합니다

## Issue Number

- Close #146 
