### PR TITLE
🐛 fix:  auth 및 profile 페이지 Keypad 외부 화면 터치 시 Keyboard가 닫기도록 수정

### DIFF
--- a/src/components/KeyboardHidePressArea/KeyboardHidePressArea.tsx
+++ b/src/components/KeyboardHidePressArea/KeyboardHidePressArea.tsx
@@ -1,0 +1,16 @@
+import React, {type PropsWithChildren} from 'react';
+
+import {Keyboard, TouchableWithoutFeedback} from 'react-native';
+
+interface Props extends PropsWithChildren {}
+
+export const KeyboardHidePressArea = ({children}: Props): React.JSX.Element => (
+  <TouchableWithoutFeedback
+    onPress={() => {
+      if (Keyboard.isVisible()) {
+        Keyboard.dismiss();
+      }
+    }}>
+    {children}
+  </TouchableWithoutFeedback>
+);

--- a/src/components/KeyboardHidePressArea/index.ts
+++ b/src/components/KeyboardHidePressArea/index.ts
@@ -1,0 +1,1 @@
+export * from './KeyboardHidePressArea';

--- a/src/screens/auth/FindIdScreen.tsx
+++ b/src/screens/auth/FindIdScreen.tsx
@@ -10,6 +10,7 @@ import {z} from 'zod';
 
 import {arrowLeftXmlData} from '../../assets/svg';
 import {Icon} from '../../components/Icon';
+import {KeyboardHidePressArea} from '../../components/KeyboardHidePressArea';
 import {Text} from '../../components/Text';
 import {
   NameSection,
@@ -107,22 +108,24 @@ export function FindIdScreen({navigation}: Props): React.JSX.Element {
   };
 
   return (
-    <SafeAreaView style={{backgroundColor: 'white', flex: 1}}>
-      <StyledTopBar>
-        <TouchableOpacity onPress={handlePressPrev}>
-          <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
-        </TouchableOpacity>
-        <Text type="head4" text={stepLabel} color="gray-500" />
-      </StyledTopBar>
+    <KeyboardHidePressArea>
+      <SafeAreaView style={{backgroundColor: 'white', flex: 1}}>
+        <StyledTopBar>
+          <TouchableOpacity onPress={handlePressPrev}>
+            <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
+          </TouchableOpacity>
+          <Text type="head4" text={stepLabel} color="gray-500" />
+        </StyledTopBar>
 
-      <currentStep.formSection
-        onNext={handlePressNext}
-        onPressSignin={handlePressSignin}
-        onPressLogin={handlePressLogin}
-        onPressFindPassword={handlePressFindPassword}
-        {...findIdForm}
-      />
-    </SafeAreaView>
+        <currentStep.formSection
+          onNext={handlePressNext}
+          onPressSignin={handlePressSignin}
+          onPressLogin={handlePressLogin}
+          onPressFindPassword={handlePressFindPassword}
+          {...findIdForm}
+        />
+      </SafeAreaView>
+    </KeyboardHidePressArea>
   );
 }
 

--- a/src/screens/auth/FindPasswordScreen.tsx
+++ b/src/screens/auth/FindPasswordScreen.tsx
@@ -10,6 +10,7 @@ import {z} from 'zod';
 
 import {arrowLeftXmlData} from '../../assets/svg';
 import {Icon} from '../../components/Icon';
+import {KeyboardHidePressArea} from '../../components/KeyboardHidePressArea';
 import {Text} from '../../components/Text';
 import {
   MobilePhoneSection,
@@ -156,22 +157,24 @@ export function FindPasswordScreen({navigation}: Props): React.JSX.Element {
   };
 
   return (
-    <SafeAreaView style={{backgroundColor: 'white', flex: 1}}>
-      <StyledTopBar>
-        <TouchableOpacity onPress={handlePressPrev}>
-          <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
-        </TouchableOpacity>
-        <Text type="head4" text={stepLabel} color="gray-500" />
-      </StyledTopBar>
+    <KeyboardHidePressArea>
+      <SafeAreaView style={{backgroundColor: 'white', flex: 1}}>
+        <StyledTopBar>
+          <TouchableOpacity onPress={handlePressPrev}>
+            <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
+          </TouchableOpacity>
+          <Text type="head4" text={stepLabel} color="gray-500" />
+        </StyledTopBar>
 
-      <currentStep.formSection
-        showLogin={showLogin}
-        onNext={handlePressNext}
-        onSubmit={handlePressSubmit}
-        onPressLogin={handlePressLogin}
-        {...findPasswordForm}
-      />
-    </SafeAreaView>
+        <currentStep.formSection
+          showLogin={showLogin}
+          onNext={handlePressNext}
+          onSubmit={handlePressSubmit}
+          onPressLogin={handlePressLogin}
+          {...findPasswordForm}
+        />
+      </SafeAreaView>
+    </KeyboardHidePressArea>
   );
 }
 

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../assets/svg';
 import {Button} from '../../components/Button';
 import {Icon} from '../../components/Icon';
+import {KeyboardHidePressArea} from '../../components/KeyboardHidePressArea';
 import {Text} from '../../components/Text';
 import {Textfield} from '../../components/Textfield/Textfield';
 import {usePostLogin} from '../../features/auth/hooks/auth';
@@ -72,114 +73,118 @@ export const LoginScreen = ({navigation}: Props): React.JSX.Element => {
   };
 
   return (
-    <SafeAreaView
-      style={{
-        backgroundColor: 'white',
-        flex: 1,
-      }}>
-      <StyledTopBar>
-        <StyledBackButton
-          onPress={() => {
-            navigation.pop();
-          }}>
-          <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
-        </StyledBackButton>
-      </StyledTopBar>
-
-      <StyledSection>
-        <Text text="일반 로그인" type="head3" fontWeight="600" />
-
-        <StyledFieldContainer>
-          <Controller
-            control={control}
-            name="uid"
-            rules={{
-              required: '아이디를 입력해주세요',
-            }}
-            render={({field: {onChange, onBlur, value}}) => (
-              <Textfield
-                label="아이디"
-                textContentType="nickname"
-                isError={formState.errors.uid != null}
-                value={value}
-                errorMessage={formState.errors.uid?.message}
-                onBlur={onBlur}
-                onChangeText={onChange}
-              />
-            )}
-          />
-
-          <Controller
-            control={control}
-            name="password"
-            rules={{
-              required: '비밀번호를 입력해주세요',
-            }}
-            render={({field: {onChange, onBlur, value}}) => (
-              <Textfield
-                label="비밀번호"
-                placeholder="영문, 숫자를 포함하여 입력해주세요."
-                textContentType="password"
-                secureTextEntry={isSecureTextEntry}
-                maxLength={16}
-                value={value}
-                isError={formState.errors.password != null}
-                errorMessage={formState.errors.password?.message}
-                onBlur={onBlur}
-                onChangeText={onChange}
-                rightElement={() => (
-                  <Pressable
-                    onPress={() => {
-                      setIsSecureTextEntry(prev => !prev);
-                    }}>
-                    <Icon
-                      svgXml={
-                        isSecureTextEntry ? eyeClosedXmlData : eyeOpenedXmlData
-                      }
-                    />
-                  </Pressable>
-                )}
-              />
-            )}
-          />
-        </StyledFieldContainer>
-        <ButtonWrapper>
-          <Button
-            text="로그인하기"
-            disabled={!formState.isValid}
-            style={{borderRadius: 12}}
+    <KeyboardHidePressArea>
+      <SafeAreaView
+        style={{
+          backgroundColor: 'white',
+          flex: 1,
+        }}>
+        <StyledTopBar>
+          <StyledBackButton
             onPress={() => {
-              void handlePressSubmit();
-            }}
-          />
-          <StyledHorizontalView>
-            <StyledTextButton
+              navigation.pop();
+            }}>
+            <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
+          </StyledBackButton>
+        </StyledTopBar>
+
+        <StyledSection>
+          <Text text="일반 로그인" type="head3" fontWeight="600" />
+
+          <StyledFieldContainer>
+            <Controller
+              control={control}
+              name="uid"
+              rules={{
+                required: '아이디를 입력해주세요',
+              }}
+              render={({field: {onChange, onBlur, value}}) => (
+                <Textfield
+                  label="아이디"
+                  textContentType="nickname"
+                  isError={formState.errors.uid != null}
+                  value={value}
+                  errorMessage={formState.errors.uid?.message}
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                />
+              )}
+            />
+
+            <Controller
+              control={control}
+              name="password"
+              rules={{
+                required: '비밀번호를 입력해주세요',
+              }}
+              render={({field: {onChange, onBlur, value}}) => (
+                <Textfield
+                  label="비밀번호"
+                  placeholder="영문, 숫자를 포함하여 입력해주세요."
+                  textContentType="password"
+                  secureTextEntry={isSecureTextEntry}
+                  maxLength={16}
+                  value={value}
+                  isError={formState.errors.password != null}
+                  errorMessage={formState.errors.password?.message}
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                  rightElement={() => (
+                    <Pressable
+                      onPress={() => {
+                        setIsSecureTextEntry(prev => !prev);
+                      }}>
+                      <Icon
+                        svgXml={
+                          isSecureTextEntry
+                            ? eyeClosedXmlData
+                            : eyeOpenedXmlData
+                        }
+                      />
+                    </Pressable>
+                  )}
+                />
+              )}
+            />
+          </StyledFieldContainer>
+          <ButtonWrapper>
+            <Button
+              text="로그인하기"
+              disabled={!formState.isValid}
+              style={{borderRadius: 12}}
               onPress={() => {
-                navigation.push('FindId');
-              }}>
-              <Text
-                text="아이디 찾기"
-                type="body2"
-                color="gray-600"
-                fontWeight="500"
-              />
-            </StyledTextButton>
-            <Text text="|" type="body2" color="gray-600" fontWeight="500" />
-            <StyledTextButton
-              onPress={() => {
-                navigation.push('FindPassword');
-              }}>
-              <Text
-                text="비밀번호 찾기"
-                type="body2"
-                color="gray-600"
-                fontWeight="500"
-              />
-            </StyledTextButton>
-          </StyledHorizontalView>
-        </ButtonWrapper>
-      </StyledSection>
-    </SafeAreaView>
+                void handlePressSubmit();
+              }}
+            />
+            <StyledHorizontalView>
+              <StyledTextButton
+                onPress={() => {
+                  navigation.push('FindId');
+                }}>
+                <Text
+                  text="아이디 찾기"
+                  type="body2"
+                  color="gray-600"
+                  fontWeight="500"
+                />
+              </StyledTextButton>
+              <Text text="|" type="body2" color="gray-600" fontWeight="500" />
+              <StyledTextButton
+                onPress={() => {
+                  navigation.push('FindPassword');
+                }}>
+                <Text
+                  text="비밀번호 찾기"
+                  type="body2"
+                  color="gray-600"
+                  fontWeight="500"
+                />
+              </StyledTextButton>
+            </StyledHorizontalView>
+          </ButtonWrapper>
+        </StyledSection>
+      </SafeAreaView>
+    </KeyboardHidePressArea>
   );
 };
 

--- a/src/screens/auth/PhysicalInfoScreen.tsx
+++ b/src/screens/auth/PhysicalInfoScreen.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/native';
 import {type NativeStackScreenProps} from '@react-navigation/native-stack';
 import {SafeAreaView} from 'react-native';
 
+import {KeyboardHidePressArea} from '../../components/KeyboardHidePressArea';
 import {Text} from '../../components/Text';
 import {PhysicalInfoForm} from '../../features/auth/components/signup';
 import {type TGender} from '../../features/my/types';
@@ -24,23 +25,25 @@ export const PhysicalInfoScreen = ({navigation}: Props): React.JSX.Element => {
   const {data: gender} = useGetBiologicalSex();
 
   return (
-    <SafeAreaView style={{backgroundColor: 'white', flex: 1}}>
-      <StyledTopBar>
-        <Text type="head4" text="[필수]" />
-      </StyledTopBar>
+    <KeyboardHidePressArea>
+      <SafeAreaView style={{backgroundColor: 'white', flex: 1}}>
+        <StyledTopBar>
+          <Text type="head4" text="[필수]" />
+        </StyledTopBar>
 
-      <PhysicalInfoForm
-        defaultWeight={weight != null ? Math.floor(weight) : undefined}
-        defaultHeight={
-          height != null ? Math.floor(height) : undefined ?? undefined
-        }
-        defaultGender={gender as TGender}
-        isAllLinked={healthKitAuthStatus?.isAllLinked ?? false}
-        onNext={() => {
-          navigation.push('Main');
-        }}
-      />
-    </SafeAreaView>
+        <PhysicalInfoForm
+          defaultWeight={weight != null ? Math.floor(weight) : undefined}
+          defaultHeight={
+            height != null ? Math.floor(height) : undefined ?? undefined
+          }
+          defaultGender={gender as TGender}
+          isAllLinked={healthKitAuthStatus?.isAllLinked ?? false}
+          onNext={() => {
+            navigation.push('Main');
+          }}
+        />
+      </SafeAreaView>
+    </KeyboardHidePressArea>
   );
 };
 

--- a/src/screens/auth/SignupScreen.tsx
+++ b/src/screens/auth/SignupScreen.tsx
@@ -11,6 +11,7 @@ import {z} from 'zod';
 
 import {arrowLeftXmlData} from '../../assets/svg';
 import {Icon} from '../../components/Icon';
+import {KeyboardHidePressArea} from '../../components/KeyboardHidePressArea';
 import {ConfirmModal} from '../../components/Modal';
 import {Text} from '../../components/Text';
 import {
@@ -199,27 +200,29 @@ export function SignupScreen({navigation}: Props): React.JSX.Element {
   };
 
   return (
-    <SafeAreaView style={{backgroundColor: 'white', flex: 1}}>
-      <StyledTopBar>
-        <TouchableOpacity onPress={handlePressPrev}>
-          <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
-        </TouchableOpacity>
-        <Text type="head4" text={stepLabel} color="gray-500" />
-      </StyledTopBar>
+    <KeyboardHidePressArea>
+      <SafeAreaView style={{backgroundColor: 'white', flex: 1}}>
+        <StyledTopBar>
+          <TouchableOpacity onPress={handlePressPrev}>
+            <Icon svgXml={arrowLeftXmlData} height={32} width={32} />
+          </TouchableOpacity>
+          <Text type="head4" text={stepLabel} color="gray-500" />
+        </StyledTopBar>
 
-      <ConfirmModal
-        visible={showErrorModal}
-        title={'회원가입에 실패했습니다'}
-        subTitle={
-          postSignupError?.message ??
-          postLoginError?.message ??
-          '다시 시도해주세요'
-        }
-        handleConfirm={handlePressConfirmError}
-      />
+        <ConfirmModal
+          visible={showErrorModal}
+          title={'회원가입에 실패했습니다'}
+          subTitle={
+            postSignupError?.message ??
+            postLoginError?.message ??
+            '다시 시도해주세요'
+          }
+          handleConfirm={handlePressConfirmError}
+        />
 
-      <currentStep.formSection onNext={handlePressNext} {...signupForm} />
-    </SafeAreaView>
+        <currentStep.formSection onNext={handlePressNext} {...signupForm} />
+      </SafeAreaView>
+    </KeyboardHidePressArea>
   );
 }
 

--- a/src/screens/my/profile/MyProfileModifyScreen.tsx
+++ b/src/screens/my/profile/MyProfileModifyScreen.tsx
@@ -14,6 +14,7 @@ import {z} from 'zod';
 
 import {theme} from '../../../assets/styles/theme';
 import {Gap} from '../../../components/Gap';
+import {KeyboardHidePressArea} from '../../../components/KeyboardHidePressArea';
 import {Text} from '../../../components/Text';
 import {TopBar} from '../../../components/TopBar';
 import {
@@ -77,25 +78,26 @@ export function MyProfileModifyScreen(): React.JSX.Element {
   const SectionComponent = MY_PROFILE_MODIFY_SECTIONS[params.type];
 
   return (
-    <>
-      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
-      <TopBar
-        headerText="프로필 편집"
-        showBackButton
-        rightComponent={() => (
-          <TouchableOpacity
-            onPress={() => {
-              void handleTopBarSave();
-            }}>
-            <Text text="저장" type="body1" color="gray-700" />
-          </TouchableOpacity>
-        )}
-      />
-      <StyledContainer>
-        <Gap size="30px" />
-        <SectionComponent {...profileForm} />
-      </StyledContainer>
-    </>
+    <KeyboardHidePressArea>
+      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}}>
+        <TopBar
+          headerText="프로필 편집"
+          showBackButton
+          rightComponent={() => (
+            <TouchableOpacity
+              onPress={() => {
+                void handleTopBarSave();
+              }}>
+              <Text text="저장" type="body1" color="gray-700" />
+            </TouchableOpacity>
+          )}
+        />
+        <StyledContainer>
+          <Gap size="30px" />
+          <SectionComponent {...profileForm} />
+        </StyledContainer>
+      </SafeAreaView>
+    </KeyboardHidePressArea>
   );
 }
 


### PR DESCRIPTION
## branch

- `main` <- `fix/keypad_area`

## Summary

- Keypad가 열려있고, Keypad 외부 화면 터치 시 Keyboard가 닫기도록 수정합니다.

## Task

- [x] `KeyboardHidePressArea` 컴포넌트 추가
- [x] `Textfield` 사용된 auth 및 profile 페이지에 `KeyboardHidePressArea` 적용

## ETC

- `KeyboardHidePressArea`에서 사용된 `TouchableWithoutFeedback` 컴포넌트는 단일 children을 받을 수 있습니다.

## Issue Number

- fix #160 
