### PR TITLE
🐛 fix: 전화번호 인증, 인증번호 확인 스크린 keyboard 수정

### DIFF
--- a/src/features/auth/components/findId/MobilePhoneSection/SendCodeSection.tsx
+++ b/src/features/auth/components/findId/MobilePhoneSection/SendCodeSection.tsx
@@ -77,6 +77,7 @@ export const SendCodeSection = ({
               label="전화번호"
               placeholder="010 1234 5678"
               textContentType="telephoneNumber"
+              keyboardType="number-pad"
               isError={error != null}
               value={numberFormatter(value)}
               onBlur={onBlur}

--- a/src/features/auth/components/findId/MobilePhoneSection/VerifySection.tsx
+++ b/src/features/auth/components/findId/MobilePhoneSection/VerifySection.tsx
@@ -123,7 +123,7 @@ export const VerifySection = ({
             <Textfield
               label="인증번호"
               placeholder="숫자로 된 인증번호 6자리를 입력해 주세요"
-              textContentType="telephoneNumber"
+              keyboardType="number-pad"
               isError={error != null || timer === 0 || isErrorPostVerify}
               isValid={isVerify}
               value={value}

--- a/src/features/auth/components/findPassword/MobilePhoneSection/SendCodeSection.tsx
+++ b/src/features/auth/components/findPassword/MobilePhoneSection/SendCodeSection.tsx
@@ -79,6 +79,7 @@ export const SendCodeSection = ({
               label="전화번호"
               placeholder="010 1234 5678"
               textContentType="telephoneNumber"
+              keyboardType="number-pad"
               isError={error != null}
               value={numberFormatter(value)}
               onBlur={onBlur}

--- a/src/features/auth/components/findPassword/MobilePhoneSection/VerifySection.tsx
+++ b/src/features/auth/components/findPassword/MobilePhoneSection/VerifySection.tsx
@@ -124,7 +124,7 @@ export const VerifySection = ({
             <Textfield
               label="인증번호"
               placeholder="숫자로 된 인증번호 6자리를 입력해 주세요"
-              textContentType="telephoneNumber"
+              keyboardType="number-pad"
               isError={error != null || timer === 0 || isErrorPostVerify}
               isValid={isVerify}
               value={value}

--- a/src/features/auth/components/signup/MobilePhoneSection/SendCodeSection.tsx
+++ b/src/features/auth/components/signup/MobilePhoneSection/SendCodeSection.tsx
@@ -76,6 +76,7 @@ export const SendCodeSection = ({
               label="전화번호"
               placeholder="010 1234 5678"
               textContentType="telephoneNumber"
+              keyboardType="number-pad"
               isError={error != null}
               value={numberFormatter(value)}
               onBlur={onBlur}

--- a/src/features/auth/components/signup/MobilePhoneSection/VerifySection.tsx
+++ b/src/features/auth/components/signup/MobilePhoneSection/VerifySection.tsx
@@ -123,7 +123,7 @@ export const VerifySection = ({
             <Textfield
               label="인증번호"
               placeholder="숫자로 된 인증번호 6자리를 입력해 주세요"
-              textContentType="telephoneNumber"
+              keyboardType="number-pad"
               isError={error != null || timer === 0 || isErrorPostVerify}
               isValid={isVerify}
               value={value}


### PR DESCRIPTION
## branch

- `main` <- `fix/mobile-verification-keypad`

## Summary

- 전화번호 인증, 인증번호 확인 스크린에서 키패드 type을 `number-pad`로 수정합니다.
- 인증번호 확인 스크린에서 키패드에서 메세지 내 숫자코드가 인식되도록 오기입된 `textContentType` 를 제거합니다.


## Task

- [x] 전화번호 인증, 인증번호 확인 페이지 `keyboardType`, `textContentType`  수정

## ETC

- 유의 사항, 참고할 내용을 추가합니다

## Issue Number

- fix #162 
