### PR TITLE
 🐛 fix: 신체정보 입력 스크린, 메인 스크린 버그 수정 및 회원 탈퇴 기능 추가

### DIFF
--- a/src/features/home/components/MainBanner.tsx
+++ b/src/features/home/components/MainBanner.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import styled from '@emotion/native';
 import {useNavigation} from '@react-navigation/native';
 import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {StatusBar, TouchableOpacity, View} from 'react-native';
+import {TouchableOpacity, View} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {alarmXmlData} from '../../../assets/svg';
 import {Icon} from '../../../components/Icon';
@@ -20,42 +21,42 @@ export const MainBanner = (): React.JSX.Element => {
     useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
 
   return (
-    <StyledTopBanner>
-      <StatusBar barStyle="light-content" />
+    <SafeAreaView>
+      <StyledTopBanner>
+        <View>
+          <StyledIconWrapper>
+            <TouchableOpacity
+              onPress={() => {
+                navigation.navigate('Notification');
+              }}>
+              <Icon svgXml={alarmXmlData} width={24} height={24} />
+            </TouchableOpacity>
+          </StyledIconWrapper>
 
-      <View>
-        <StyledIconWrapper>
-          <TouchableOpacity
-            onPress={() => {
-              navigation.navigate('Notification');
-            }}>
-            <Icon svgXml={alarmXmlData} width={24} height={24} />
-          </TouchableOpacity>
-        </StyledIconWrapper>
+          {myProfileDetail != null && (
+            <Text
+              type="head3"
+              color={'gray-0'}
+              lineHeight="33.6px"
+              fontWeight="700"
+              text={`${myProfileDetail?.name} 님, \n오늘도 목표를 향해 \n달려볼까요?🔥`}
+            />
+          )}
+        </View>
 
-        {myProfileDetail != null && (
+        {userFieldProgress != null && (
           <Text
-            type="head3"
-            color={'gray-0'}
-            lineHeight="33.6px"
-            fontWeight="700"
-            text={`${myProfileDetail?.name} 님, \n오늘도 목표를 향해 \n달려볼까요?🔥`}
+            type="body3"
+            color="gray-600"
+            fontWeight="600"
+            text={`현재 진행 중인 매칭 ${userFieldProgress.length}개`}
           />
         )}
-      </View>
-
-      {userFieldProgress != null && (
-        <Text
-          type="body3"
-          color="gray-600"
-          fontWeight="600"
-          text={`현재 진행 중인 매칭 ${userFieldProgress.length}개`}
+        <StyledImage
+          source={require('../../../assets/images/main-character-image.png')}
         />
-      )}
-      <StyledImage
-        source={require('../../../assets/images/main-character-image.png')}
-      />
-    </StyledTopBanner>
+      </StyledTopBanner>
+    </SafeAreaView>
   );
 };
 

--- a/src/features/home/components/MainBanner.tsx
+++ b/src/features/home/components/MainBanner.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/native';
 import {useNavigation} from '@react-navigation/native';
 import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {TouchableOpacity, View} from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {alarmXmlData} from '../../../assets/svg';
 import {Icon} from '../../../components/Icon';
@@ -21,7 +20,7 @@ export const MainBanner = (): React.JSX.Element => {
     useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
 
   return (
-    <SafeAreaView>
+    <View>
       <StyledTopBanner>
         <View>
           <StyledIconWrapper>
@@ -56,7 +55,7 @@ export const MainBanner = (): React.JSX.Element => {
           source={require('../../../assets/images/main-character-image.png')}
         />
       </StyledTopBanner>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/src/features/home/components/MatchPreviewSection/NoMatching.tsx
+++ b/src/features/home/components/MatchPreviewSection/NoMatching.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 
 import styled from '@emotion/native';
+import {useNavigation} from '@react-navigation/native';
+import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
 
 import {Text} from '../../../../components/Text';
+import {type MatchStackParamList} from '../../../../navigators';
 
 export const NoMatching = (): React.JSX.Element => {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<MatchStackParamList>>();
+
   return (
     <StyledNoMatchingContainer>
       <Text
@@ -13,7 +19,20 @@ export const NoMatching = (): React.JSX.Element => {
         color="gray-600"
         type="body3"
       />
-      <StyledMatchingButton>
+      <StyledMatchingButton
+        onPress={() => {
+          navigation.navigate('MatchList', {
+            page: 0,
+            size: 10,
+            fieldType: 'DUEL',
+            goal: [],
+            memberCount: null,
+            period: [],
+            skillLevel: [],
+            strength: [],
+            keyword: '',
+          });
+        }}>
         <Text
           text="매칭 상대 찾아보기"
           type="body3"

--- a/src/features/home/components/TodayCalorieSection/TodayCalorieSection.tsx
+++ b/src/features/home/components/TodayCalorieSection/TodayCalorieSection.tsx
@@ -2,18 +2,17 @@ import React from 'react';
 
 import styled from '@emotion/native';
 
-import {Gap} from '../../../components/Gap';
-import {Text} from '../../../components/Text';
-import {dayjs} from '../../../lib/dayjs';
-import {useGetBurnedCalorieGoal} from '../../record/hooks/exercise';
+import {TodayCalorieSectionButton} from './TodayCalorieSectionButton';
+import {Gap} from '../../../../components/Gap';
+import {Text} from '../../../../components/Text';
+import {dayjs} from '../../../../lib/dayjs';
+import {useGetBurnedCalorieGoal} from '../../../record/hooks/exercise';
 
 export const TodayCalorieSection = (): React.JSX.Element => {
   const today = dayjs().format('YYYY-MM-DD');
-
-  const {data: burnedCalorieGoal, refetch: refetchBurnedCalorieGoal} =
-    useGetBurnedCalorieGoal({
-      date: today,
-    });
+  const {data: burnedCalorieGoal} = useGetBurnedCalorieGoal({
+    date: today,
+  });
 
   const achievementPercent = (
     ((burnedCalorieGoal?.burnedCalorie ?? 0) /
@@ -44,17 +43,7 @@ export const TodayCalorieSection = (): React.JSX.Element => {
           fontWeight="700"
           color="gray-700"
         />
-        <StyledResetButton
-          onPress={() => {
-            void refetchBurnedCalorieGoal();
-          }}>
-          <Text
-            text="새로고침"
-            type="caption"
-            fontWeight="600"
-            color="gray-600"
-          />
-        </StyledResetButton>
+        <TodayCalorieSectionButton />
       </StyledCalorieContainer>
 
       <StyledGraphWrapper>
@@ -82,12 +71,6 @@ const StyledCalorieContainer = styled.View`
   align-items: flex-end;
   justify-content: space-between;
   margin-top: 2px;
-`;
-
-const StyledResetButton = styled.TouchableOpacity`
-  border-radius: 12.449px;
-  background: #f0f0f5;
-  padding: 8px 11px;
 `;
 
 const StyledGraphWrapper = styled.View`

--- a/src/features/home/components/TodayCalorieSection/TodayCalorieSectionButton.tsx
+++ b/src/features/home/components/TodayCalorieSection/TodayCalorieSectionButton.tsx
@@ -15,16 +15,9 @@ export const TodayCalorieSectionButton = (): React.JSX.Element => {
 
   const {data: healthKitAuthStatus} = useGetHealthKitAuthStatus();
 
-  // const {mutate: initHealthKit} = useInitHealthKit();
-
-  const StyledResetContainer =
-    healthKitAuthStatus?.isAllLinked ?? false
-      ? StyledResetButton
-      : StyledResetText;
-
   return (
-    <StyledResetContainer
-      disabled={healthKitAuthStatus?.isAllLinked ?? false}
+    <StyledResetButton
+      disabled={!(healthKitAuthStatus?.isAllLinked ?? false)}
       onPress={() => {
         if (healthKitAuthStatus?.isAllLinked ?? false) {
           void refetchBurnedCalorieGoal();
@@ -44,17 +37,11 @@ export const TodayCalorieSectionButton = (): React.JSX.Element => {
         fontWeight="600"
         color="gray-600"
       />
-    </StyledResetContainer>
+    </StyledResetButton>
   );
 };
 
 const StyledResetButton = styled.TouchableOpacity`
-  border-radius: 12.449px;
-  background: #f0f0f5;
-  padding: 8px 11px;
-`;
-
-const StyledResetText = styled.View`
   border-radius: 12.449px;
   background: #f0f0f5;
   padding: 8px 11px;

--- a/src/features/home/components/TodayCalorieSection/TodayCalorieSectionButton.tsx
+++ b/src/features/home/components/TodayCalorieSection/TodayCalorieSectionButton.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import styled from '@emotion/native';
+import dayjs from 'dayjs';
+
+import {Text} from '../../../../components/Text';
+import {useGetHealthKitAuthStatus} from '../../../../hooks/healthKit';
+import {useGetBurnedCalorieGoal} from '../../../record/hooks/exercise';
+
+export const TodayCalorieSectionButton = (): React.JSX.Element => {
+  const today = dayjs().format('YYYY-MM-DD');
+  const {refetch: refetchBurnedCalorieGoal} = useGetBurnedCalorieGoal({
+    date: today,
+  });
+
+  const {data: healthKitAuthStatus} = useGetHealthKitAuthStatus();
+
+  // const {mutate: initHealthKit} = useInitHealthKit();
+
+  const StyledResetContainer =
+    healthKitAuthStatus?.isAllLinked ?? false
+      ? StyledResetButton
+      : StyledResetText;
+
+  return (
+    <StyledResetContainer
+      disabled={healthKitAuthStatus?.isAllLinked ?? false}
+      onPress={() => {
+        if (healthKitAuthStatus?.isAllLinked ?? false) {
+          void refetchBurnedCalorieGoal();
+        }
+        //  else {
+        //  NOTE: 기기당 한번씩만 설정 가능
+        //   initHealthKit(defaultPermissions);
+        // }
+      }}>
+      <Text
+        text={
+          healthKitAuthStatus?.isAllLinked ?? false
+            ? '새로고침'
+            : '건강앱 미연동'
+        }
+        type="caption"
+        fontWeight="600"
+        color="gray-600"
+      />
+    </StyledResetContainer>
+  );
+};
+
+const StyledResetButton = styled.TouchableOpacity`
+  border-radius: 12.449px;
+  background: #f0f0f5;
+  padding: 8px 11px;
+`;
+
+const StyledResetText = styled.View`
+  border-radius: 12.449px;
+  background: #f0f0f5;
+  padding: 8px 11px;
+`;

--- a/src/features/home/components/TodayCalorieSection/index.ts
+++ b/src/features/home/components/TodayCalorieSection/index.ts
@@ -1,0 +1,1 @@
+export * from './TodayCalorieSection';

--- a/src/features/my/hooks/profile/index.ts
+++ b/src/features/my/hooks/profile/index.ts
@@ -1,2 +1,3 @@
 export * from './useGetMyProfileDetail';
 export * from './usePatchMyOnboardProfile';
+export * from './useGetMyWithdraw';

--- a/src/features/my/hooks/profile/keys.ts
+++ b/src/features/my/hooks/profile/keys.ts
@@ -3,4 +3,5 @@ export const KEYS = {
 
   profileDetail: () => [...KEYS.all, 'profile-detail'] as const,
   onboardProfile: () => [...KEYS.all, 'onboard-profile'] as const,
+  withdraw: () => [...KEYS.all, 'withdraw'] as const,
 };

--- a/src/features/my/hooks/profile/useGetMyWithdraw.ts
+++ b/src/features/my/hooks/profile/useGetMyWithdraw.ts
@@ -1,0 +1,39 @@
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+
+import {KEYS} from './keys';
+import {ASYNC_STORAGE_KEYS, asyncStorage} from '../../../../lib/asyncStorage';
+import {axios} from '../../../../lib/axios';
+
+const fetcher = async (): Promise<string> =>
+  await axios.get(`/users/my/withdraw`).then(({data}) => data);
+
+interface IProps {
+  options: {
+    enabled?: boolean;
+    onSuccessCallback?: () => void;
+  };
+}
+
+export const useGetMyWithdraw = ({
+  options,
+}: IProps): UseQueryResult<string, Error> =>
+  useQuery({
+    queryKey: KEYS.withdraw(),
+    queryFn: async () => await fetcher(),
+    enabled: options?.enabled,
+    onSuccess: () => {
+      void asyncStorage.remove(ASYNC_STORAGE_KEYS.AUTH_JWT_ACCESS_TOKEN);
+      void asyncStorage.remove(ASYNC_STORAGE_KEYS.AUTH_JWT_REFRESH_TOKEN);
+
+      options?.onSuccessCallback?.();
+    },
+  });
+
+// export const useGetMyWithdraw = (
+//   {enabled} = {enabled: false},
+// ): UseQueryResult<string, Error> =>
+//   useQuery({
+//     queryKey: KEYS.withdraw(),
+//     queryFn: async () => await fetcher(),
+//     enabled,
+//   });

--- a/src/features/my/hooks/profile/usePatchMyOnboardProfile.ts
+++ b/src/features/my/hooks/profile/usePatchMyOnboardProfile.ts
@@ -15,7 +15,7 @@ interface IProps {
 
 const fetcher = async ({body}: IProps): Promise<string> =>
   await axios
-    .post(`/users/my/onboard-profile`, body, {
+    .patch(`/users/my/onboard-profile`, body, {
       headers: {'Content-Type': 'application/json'},
     })
     .then(({data}) => data);

--- a/src/features/record/components/CreateWorkoutInformation/ExpectedBurnedCaloriesSection.tsx
+++ b/src/features/record/components/CreateWorkoutInformation/ExpectedBurnedCaloriesSection.tsx
@@ -26,7 +26,7 @@ export const ExpectedBurnedCaloriesSection = ({
   useEffect(() => {
     if (burnedCalorie === undefined) return;
     setWorkoutForm('energyBurned', burnedCalorie);
-  }, [workoutType, durationMinute]);
+  }, [burnedCalorie]);
 
   return (
     <StyledExpectedBurnedCaloriesSection>

--- a/src/features/record/components/CreateWorkoutInformation/Modal/WorkoutActivityTypeModal.tsx
+++ b/src/features/record/components/CreateWorkoutInformation/Modal/WorkoutActivityTypeModal.tsx
@@ -69,7 +69,12 @@ export const WorkoutActivityTypeModal = ({
                   onPress={() => {
                     setSelectedWorkoutType(workoutType);
                   }}>
-                  <CheckBox isCheck={workoutType === selectedWorkoutType} />
+                  <CheckBox
+                    isCheck={workoutType === selectedWorkoutType}
+                    onPress={() => {
+                      setSelectedWorkoutType(workoutType);
+                    }}
+                  />
                   <Text
                     text={label}
                     type="body2"

--- a/src/features/record/hooks/exercise/useGetExpectedBurnedCalorie.ts
+++ b/src/features/record/hooks/exercise/useGetExpectedBurnedCalorie.ts
@@ -11,7 +11,7 @@ interface IProps {
 
 const fetcher = async ({durationMinute, sports}: IProps): Promise<number> =>
   await axios
-    .get(`/exercise/my-summary`, {
+    .get(`/exercise/expected-burned-calorie`, {
       params: {
         durationMinute,
         sports,

--- a/src/hooks/healthKit/useGetHealthKitAuthStatus.ts
+++ b/src/hooks/healthKit/useGetHealthKitAuthStatus.ts
@@ -6,18 +6,30 @@ import {
   HealthStatusCode,
   type HealthKitPermissions,
   type HealthStatusResult,
+  defaultPermissions,
 } from '../../lib/AppleHealthKit';
 
 interface IHealthStatusResult extends HealthStatusResult {
   isAllLinked: boolean;
 }
 
+interface IProps {
+  permissions?: HealthKitPermissions;
+  options?: {
+    enabled?: boolean;
+  };
+}
+
 export const useGetHealthKitAuthStatus = (
-  permissions?: HealthKitPermissions,
+  {permissions, options}: IProps = {
+    permissions: defaultPermissions,
+    options: {enabled: true},
+  },
 ): UseQueryResult<IHealthStatusResult, Error> =>
   useQuery({
     queryKey: KEYS.auth(permissions),
     queryFn: async () => await getAuthStatus(permissions),
+    enabled: options?.enabled,
     initialData: {
       permissions: {
         read: [],
@@ -27,7 +39,7 @@ export const useGetHealthKitAuthStatus = (
     select: healthKitAuthStatus => {
       const isAllLinked = Object.values(healthKitAuthStatus.permissions)
         .flat()
-        .every(permission => permission === HealthStatusCode.SharingAuthorized);
+        .every(permission => permission !== HealthStatusCode.NotDetermined);
       return {...healthKitAuthStatus, isAllLinked};
     },
   });

--- a/src/hooks/healthKit/useGetHealthKitAuthStatus.ts
+++ b/src/hooks/healthKit/useGetHealthKitAuthStatus.ts
@@ -25,9 +25,9 @@ export const useGetHealthKitAuthStatus = (
       },
     },
     select: healthKitAuthStatus => {
-      const isAllLinked = !Object.values(healthKitAuthStatus.permissions)
+      const isAllLinked = Object.values(healthKitAuthStatus.permissions)
         .flat()
-        .some(permission => permission === HealthStatusCode.NotDetermined);
+        .every(permission => permission === HealthStatusCode.SharingAuthorized);
       return {...healthKitAuthStatus, isAllLinked};
     },
   });

--- a/src/hooks/healthKit/useInitHealthKit.ts
+++ b/src/hooks/healthKit/useInitHealthKit.ts
@@ -7,7 +7,14 @@ import {
 } from '../../lib/AppleHealthKit';
 import {queryClient} from '../../lib/react-query';
 
-export const useInitHealthKit = (): UseMutationResult<
+interface IProps {
+  options?: {
+    onSuccessCallback?: () => void;
+    onErrorCallback?: () => void;
+  };
+}
+
+export const useInitHealthKit = ({options}: IProps = {}): UseMutationResult<
   void,
   unknown,
   HealthKitPermissions | undefined,
@@ -15,9 +22,12 @@ export const useInitHealthKit = (): UseMutationResult<
 > => {
   return useMutation({
     mutationFn: initHealthKit,
-    onSuccess: () => {
-      void queryClient.invalidateQueries(KEYS.all);
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(KEYS.all);
+
       console.log('init HealthKit');
+      options?.onSuccessCallback?.();
     },
+    onError: options?.onErrorCallback,
   });
 };

--- a/src/lib/AppleHealthKit/AppleHealthKit.ts
+++ b/src/lib/AppleHealthKit/AppleHealthKit.ts
@@ -74,7 +74,10 @@ export const getLatestHeight = async (): Promise<
       if (error != null) {
         resolve({value: null});
       } else {
-        resolve(results);
+        resolve({
+          ...results,
+          value: results.value * 2.54, // inch to cm
+        });
       }
     });
   });
@@ -90,7 +93,7 @@ export const getLatestWeight = async (): Promise<
           // NOTE: data 없을 경우 error 발생
           resolve({value: null});
         } else {
-          resolve(results);
+          resolve({...results, value: results.value / 1000}); // gram to kilogram
         }
       },
     );

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {type NativeStackScreenProps} from '@react-navigation/native-stack';
-import {ScrollView} from 'react-native';
+import {SafeAreaView, ScrollView} from 'react-native';
 
 import {theme} from '../../assets/styles/theme';
 import {
@@ -16,11 +16,13 @@ type Props = NativeStackScreenProps<HomeStackParamList, 'HomeMain'>;
 
 export function HomeScreen({navigation}: Props): React.JSX.Element {
   return (
-    <ScrollView style={{backgroundColor: theme.palette['gray-0']}}>
-      <MainBanner />
-      <TodayCalorieSection />
-      <MatchPreviewSection />
-      <CurrentWorkoutSection />
-    </ScrollView>
+    <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}}>
+      <ScrollView>
+        <MainBanner />
+        <TodayCalorieSection />
+        <MatchPreviewSection />
+        <CurrentWorkoutSection />
+      </ScrollView>
+    </SafeAreaView>
   );
 }

--- a/src/screens/home/NotificationScreen.tsx
+++ b/src/screens/home/NotificationScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from '@emotion/native';
 import {type NativeStackScreenProps} from '@react-navigation/native-stack';
-import {SafeAreaView, ScrollView, StatusBar, View} from 'react-native';
+import {SafeAreaView, ScrollView, View} from 'react-native';
 
 import {theme} from '../../assets/styles/theme';
 import {Text} from '../../components/Text';
@@ -29,8 +29,7 @@ export function NotificationScreen({navigation}: Props): React.JSX.Element {
 
   return (
     <>
-      <StatusBar barStyle="default" />
-      <SafeAreaView />
+      <SafeAreaView style={{backgroundColor: theme.palette['gray-0']}} />
       <StyledTopBar>
         <StyledTopBarButton
           onPress={() => {

--- a/src/screens/my/setting/SettingResignationScreen.tsx
+++ b/src/screens/my/setting/SettingResignationScreen.tsx
@@ -1,6 +1,8 @@
 import React, {useMemo, useState} from 'react';
 
 import styled from '@emotion/native';
+import {useNavigation} from '@react-navigation/native';
+import {type NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {SafeAreaView} from 'react-native';
 
 import {theme} from '../../../assets/styles/theme';
@@ -10,6 +12,8 @@ import {LinedCheckBox} from '../../../components/CheckBox/LinedCheckBox';
 import {Gap} from '../../../components/Gap';
 import {TopBar} from '../../../components/TopBar';
 import {ResignationAchievementCard} from '../../../features/my/components';
+import {useGetMyWithdraw} from '../../../features/my/hooks/profile';
+import {type RootStackParamList} from '../../../navigators';
 
 interface ITerms {
   personalInfo: boolean;
@@ -41,6 +45,18 @@ export function SettingResignationScreen(): React.JSX.Element {
   const isAllTermsChecked = useMemo(() => {
     return Object.values(terms).every(isChecked => isChecked);
   }, [terms]);
+
+  const appNavigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  const {refetch: withdraw} = useGetMyWithdraw({
+    options: {
+      enabled: false,
+      onSuccessCallback: () => {
+        appNavigation.replace('Landing');
+      },
+    },
+  });
 
   return (
     <>
@@ -89,7 +105,7 @@ export function SettingResignationScreen(): React.JSX.Element {
             variant="tertiary"
             disabled={!isAllTermsChecked}
             onPress={() => {
-              // TODO(@minimalKim): 탈퇴 API 연동 및 다시 온보딩 화면으로 이동
+              void withdraw();
             }}
           />
         </FixedButtonWrapper>

--- a/src/screens/my/setting/SettingScreen.tsx
+++ b/src/screens/my/setting/SettingScreen.tsx
@@ -38,8 +38,7 @@ export function SettingScreen(): React.JSX.Element {
     options: {
       enabled: false,
       onSuccessCallback: () => {
-        appNavigation.popToTop();
-        appNavigation.navigate('Landing');
+        appNavigation.replace('Landing');
       },
     },
   });


### PR DESCRIPTION
## branch

- `main` <- `fix/main`

## Summary

- 신체정보 입력 스크린, 메인 스크린에서 발생하는 버그를 수정합니다.
- 회원 탈퇴 기능을 추가합니다.

## Task

- 신체정보 입력 스크린
  - [x] 신체정보 입력 API method 오기입 수정
  - [x] InitHealthKit(건강앱 접근 허가를 위한 Native Bottom Sheet)실행 이후 접근 권한 관련 데이터 업데이트 되지 않는 이슈 임시 해결
    - invalidateQueries가 정상 동작하지 않는 것으로 파악되었으며 임시로 해결하였습니다. 코드에 오류가 있는지 또는 버그 픽스된 버전이 있는지 추후 추가로 알아보겠습니다.
  - [x] 건강앱 접근이 부분적으로 허가된 유저일 경우, AppleHealthKit에서 조회한 신장(height)이 `inch` -> `cm`, 몸무게(weight)가 `gram` ->`kg` 기준으로 단위 계산 수정
- 메인 스크린
  - [x] 상단 Statusbar 변경된 디자인 명세 반영
  - [x] 미연동 유저일 경우 '연동하기' 버튼 -> '건강앱 미연동' 안내 텍스트로 변경
     - InitHealthKit가 설치된 앱에서 한번만 실행가능하여, 이전에 InitHealthKit가 실행된 후 '연동하기' 버튼을 눌러도 재실행이 불가능한 이슈가 있습니다. 해당 버그 우선 수정되었으며, 디자이너에게 이슈 공유 예정입니다.
  - [x] '매칭 상대 찾아보기' 클릭 시 매칭 스크린으로 navigate 기능 추가
 
 - 마이페이지 스크린
   - [x] 회원탈퇴 기능 추가
   - [x] 로그아웃 이후 뒤로가기 방지
  
  
## ETC

- 급하게 작업하여 버그 픽스 PR과 기능 추가 PR를 분리하지 않고 함께 올리게 된 점 양해 부탁드립니다... 🙏

## Issue Number

